### PR TITLE
Wire in CityCodes from ClusterProfiles during workload validation.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,5 +27,8 @@
       ]
     }
   },
-  "onCreateCommand": "bash .devcontainer/post-install.sh"
+  "onCreateCommand": "bash .devcontainer/post-install.sh",
+  "mounts": [
+    "source=${localWorkspaceFolder}/../network-services-operator,target=/workspaces/network-services-operator,type=bind"
+  ]
 }

--- a/api/v1alpha/workload_types.go
+++ b/api/v1alpha/workload_types.go
@@ -71,6 +71,11 @@ type WorkloadStatus struct {
 	Gateway *WorkloadGatewayStatus `json:"gateway,omitempty"`
 }
 
+const (
+	// WorkloadAvailable indicates that at least one instance has come online.
+	WorkloadAvailable = "Available"
+)
+
 type WorkloadGatewayStatus struct {
 	gatewayv1.GatewayStatus `json:",inline"`
 

--- a/api/v1alpha/workloaddeployment_types.go
+++ b/api/v1alpha/workloaddeployment_types.go
@@ -57,6 +57,12 @@ type WorkloadDeploymentStatus struct {
 	// TODO(jreese) ReadyReplicas?
 }
 
+const (
+	// WorkloadDeploymentAvailable indicates that at least one instance has come
+	// online.
+	WorkloadDeploymentAvailable = "Available"
+)
+
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,0 +1,22 @@
+# This kustomization.yaml is not intended to be run by itself,
+# since it depends on service name and namespace that are out of this kustomize package.
+# It should be run by config/default
+resources:
+- bases/compute.datumapis.com_instances.yaml
+- bases/compute.datumapis.com_workloaddeployments.yaml
+- bases/compute.datumapis.com_workloads.yaml
+# +kubebuilder:scaffold:crdkustomizeresource
+
+patches:
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
+# patches here are for enabling the conversion webhook for each CRD
+# +kubebuilder:scaffold:crdkustomizewebhookpatch
+
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
+# patches here are for enabling the CA injection for each CRD
+# +kubebuilder:scaffold:crdkustomizecainjectionpatch
+
+# [WEBHOOK] To enable webhook, uncomment the following section
+# the following config is for teaching kustomize how to do kustomization for CRDs.
+#configurations:
+#- kustomizeconfig.yaml

--- a/config/crd/kustomizeconfig.yaml
+++ b/config/crd/kustomizeconfig.yaml
@@ -1,0 +1,19 @@
+# This file is for teaching kustomize how to substitute name and namespace reference in CRD
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: CustomResourceDefinition
+    version: v1
+    group: apiextensions.k8s.io
+    path: spec/conversion/webhook/clientConfig/service/name
+
+namespace:
+- kind: CustomResourceDefinition
+  version: v1
+  group: apiextensions.k8s.io
+  path: spec/conversion/webhook/clientConfig/service/namespace
+  create: false
+
+varReference:
+- path: metadata/annotations

--- a/internal/controller/workload_controller.go
+++ b/internal/controller/workload_controller.go
@@ -362,7 +362,6 @@ func (r *WorkloadReconciler) getDeploymentsForWorkload(
 	}
 
 	var clusterProfiles clusterinventoryv1alpha1.ClusterProfileList
-
 	if err := r.Client.List(ctx, &clusterProfiles); err != nil {
 		return nil, nil, fmt.Errorf("failed to list cluster profiles: %w", err)
 	}

--- a/internal/controller/workloaddeployment_scheduler.go
+++ b/internal/controller/workloaddeployment_scheduler.go
@@ -53,7 +53,6 @@ func (r *WorkloadDeploymentScheduler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Step 1: Get ClusterProfiles
 	var clusterProfiles clusterinventoryv1alpha1.ClusterProfileList
-
 	if err := r.Client.List(ctx, &clusterProfiles); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to list cluster profiles: %w", err)
 	}

--- a/internal/validation/workload_validation_test.go
+++ b/internal/validation/workload_validation_test.go
@@ -605,6 +605,10 @@ func TestValidateWorkloads(t *testing.T) {
 			},
 		)
 
+		if len(scenario.opts.ValidCityCodes) == 0 {
+			scenario.opts.ValidCityCodes = []string{"DFW"}
+		}
+
 		t.Run(name, func(t *testing.T) {
 			errs := ValidateWorkloadCreate(scenario.workload, scenario.opts)
 


### PR DESCRIPTION
- Updated the dev container to mount in the expected network-services-operator path, and added some constants for condition types.
- Added missing kustomize config files.