### PR TITLE
bug: Propagate Extra field from UserInfo in the admission request through the SubjectAccessReview to check for network use.

### DIFF
--- a/internal/validation/instance_validation.go
+++ b/internal/validation/instance_validation.go
@@ -97,6 +97,11 @@ func validateInstanceNetworkInterfaces(
 			allErrs = append(allErrs, field.Invalid(networkNameField, networkInterface.Network, msg))
 		}
 
+		extra := map[string]authorizationv1.ExtraValue{}
+		for k, v := range opts.AdmissionRequest.UserInfo.Extra {
+			extra[k] = authorizationv1.ExtraValue(v)
+		}
+
 		review := authorizationv1.SubjectAccessReview{
 			Spec: authorizationv1.SubjectAccessReviewSpec{
 				ResourceAttributes: &authorizationv1.ResourceAttributes{
@@ -108,6 +113,7 @@ func validateInstanceNetworkInterfaces(
 					Namespace: opts.Workload.Namespace,
 				},
 				User:   opts.AdmissionRequest.UserInfo.Username,
+				Extra:  extra,
 				Groups: opts.AdmissionRequest.UserInfo.Groups,
 				UID:    opts.AdmissionRequest.UserInfo.UID,
 			},


### PR DESCRIPTION
A user reported encountering the following error while attempting to create a workload:

```
The Workload "my-container-workload" is invalid: spec.template.spec.networkInterfaces[0].network: Forbidden: permission to use the network was denied
```

After investigating this problem, it was determined that we are not propagating the `Extra` information provided in the admission request to the SubjectAccessReview that the validating webhook uses to confirm the caller has access to use a network. This field is used by the authorization layer to propagate organization and project information required by the upstream IAM system. Without this information, a correct policy to grant access cannot be found.


Link to conversation: https://datum-community.slack.com/archives/C07UKR3FFK7/p1740594405324389?thread_ts=1740501326.617879&cid=C07UKR3FFK7