### PR TITLE
Add labels to WorkloadDeployment and Instance resources to support filtering.

### DIFF
--- a/api/v1alpha/labels.go
+++ b/api/v1alpha/labels.go
@@ -1,0 +1,8 @@
+package v1alpha
+
+const (
+	LabelNamespace = "compute.datumapis.com"
+
+	WorkloadUIDLabel           = AnnotationNamespace + "/workload-uid"
+	WorkloadDeploymentUIDLabel = AnnotationNamespace + "/workload-deployment-uid"
+)

--- a/api/v1alpha/labels.go
+++ b/api/v1alpha/labels.go
@@ -3,6 +3,6 @@ package v1alpha
 const (
 	LabelNamespace = "compute.datumapis.com"
 
-	WorkloadUIDLabel           = AnnotationNamespace + "/workload-uid"
-	WorkloadDeploymentUIDLabel = AnnotationNamespace + "/workload-deployment-uid"
+	WorkloadUIDLabel           = LabelNamespace + "/workload-uid"
+	WorkloadDeploymentUIDLabel = LabelNamespace + "/workload-deployment-uid"
 )

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -160,6 +160,13 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "WorkloadDeploymentScheduler")
 		os.Exit(1)
 	}
+	if err = (&controller.InstanceReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Instance")
+		os.Exit(1)
+	}
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = computewebhooks.SetupWorkloadWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Workload")

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
+	github.com/stretchr/testify v1.9.0
 	go.datum.net/network-services-operator v0.0.0-20250102193121-b4bcc249023a
 	golang.org/x/crypto v0.31.0
 	google.golang.org/protobuf v1.35.1
@@ -54,6 +55,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect

--- a/internal/controller/instance_controller.go
+++ b/internal/controller/instance_controller.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	computev1alpha "go.datum.net/workload-operator/api/v1alpha"
+)
+
+// InstanceReconciler reconciles an Instance object
+type InstanceReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=compute.datumapis.com,resources=instances,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=compute.datumapis.com,resources=instances/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=compute.datumapis.com,resources=instances/finalizers,verbs=update
+
+func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	var instance computev1alpha.Instance
+	if err := r.Client.Get(ctx, req.NamespacedName, &instance); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if !instance.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("reconciling instance")
+	defer logger.Info("reconcile complete")
+
+	// Ensure the instance has labels necessary for being able to identify
+	// instances associated with a specific workload or workload deployment via
+	// label selectors.
+	//
+	// This logic will not be necessary once we complete the work defined in
+	// https://github.com/datum-cloud/enhancements/issues/28
+
+	workloadDeploymentRef := metav1.GetControllerOf(&instance)
+	if workloadDeploymentRef == nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get controller owner of Instance")
+	}
+
+	var workloadDeployment computev1alpha.WorkloadDeployment
+	workloadDeploymentObjectKey := client.ObjectKey{
+		Namespace: instance.Namespace,
+		Name:      workloadDeploymentRef.Name,
+	}
+	if err := r.Client.Get(ctx, workloadDeploymentObjectKey, &workloadDeployment); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	workloadRef := metav1.GetControllerOf(&workloadDeployment)
+	if workloadRef == nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get controller owner of WorkloadDeployment")
+	}
+
+	updated := instance.DeepCopy()
+	if updated.Labels == nil {
+		updated.Labels = map[string]string{}
+	}
+	updated.Labels[computev1alpha.WorkloadUIDLabel] = string(workloadRef.UID)
+	updated.Labels[computev1alpha.WorkloadDeploymentUIDLabel] = string(workloadDeploymentRef.UID)
+
+	if !equality.Semantic.DeepEqual(updated, instance) {
+		if err := r.Client.Update(ctx, updated); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed updating instance: %w", err)
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *InstanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&computev1alpha.Instance{}).
+		Complete(r)
+}

--- a/internal/controller/instance_controller_test.go
+++ b/internal/controller/instance_controller_test.go
@@ -1,0 +1,161 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	computev1alpha "go.datum.net/workload-operator/api/v1alpha"
+)
+
+func TestInstanceReconciler(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(computev1alpha.AddToScheme(scheme))
+
+	tests := []struct {
+		name           string
+		objs           []client.Object
+		req            ctrl.Request
+		expectedErr    string
+		expectedLabels map[string]string
+	}{
+		{
+			name: "missing controller owner in instance",
+			objs: []client.Object{
+				&computev1alpha.Instance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "instance-no-owner",
+						Namespace: "default",
+					},
+				},
+			},
+			req:         ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "instance-no-owner"}},
+			expectedErr: "failed to get controller owner of Instance",
+		},
+		{
+			name: "workload deployment not found",
+			objs: []client.Object{
+				&computev1alpha.Instance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "instance-missing-wd",
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "compute.datumapis.com/v1alpha",
+								Kind:       "WorkloadDeployment",
+								Name:       "wd1",
+								UID:        "33c325cb-3f2e-4b2a-be0c-6d7e03aa475a",
+								Controller: proto.Bool(true),
+							},
+						},
+					},
+				},
+			},
+			req:         ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "instance-missing-wd"}},
+			expectedErr: "not found",
+		},
+		{
+			name: "missing controller owner in workload deployment",
+			objs: []client.Object{
+				&computev1alpha.Instance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "instance-wd-no-owner",
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "compute.datumapis.com/v1alpha",
+								Kind:       "WorkloadDeployment",
+								Name:       "wd1",
+								UID:        "33c325cb-3f2e-4b2a-be0c-6d7e03aa475a",
+								Controller: proto.Bool(true),
+							},
+						},
+					},
+				},
+				&computev1alpha.WorkloadDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "wd1",
+						Namespace: "default",
+						// Missing controller owner
+					},
+				},
+			},
+			req:         ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "instance-wd-no-owner"}},
+			expectedErr: "failed to get controller owner of WorkloadDeployment",
+		},
+		{
+			name: "successful reconcile and update",
+			objs: []client.Object{
+				&computev1alpha.Instance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "instance-success",
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "compute.datumapis.com/v1alpha",
+								Kind:       "WorkloadDeployment",
+								Name:       "wd1",
+								UID:        "33c325cb-3f2e-4b2a-be0c-6d7e03aa475a",
+								Controller: proto.Bool(true),
+							},
+						},
+					},
+				},
+				&computev1alpha.WorkloadDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "wd1",
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "compute.datumapis.com/v1alpha",
+								Kind:       "Workload",
+								Name:       "w1",
+								UID:        "2561b624-3f7d-49db-bc74-b9dc71c4c08d",
+								Controller: proto.Bool(true),
+							},
+						},
+					},
+				},
+			},
+			req:         ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "instance-success"}},
+			expectedErr: "",
+			expectedLabels: map[string]string{
+				computev1alpha.WorkloadUIDLabel:           "2561b624-3f7d-49db-bc74-b9dc71c4c08d",
+				computev1alpha.WorkloadDeploymentUIDLabel: "33c325cb-3f2e-4b2a-be0c-6d7e03aa475a",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(tc.objs...).Build()
+			reconciler := &InstanceReconciler{Client: cl, Scheme: scheme}
+			_, err := reconciler.Reconcile(context.Background(), tc.req)
+
+			// Check error
+			if tc.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.expectedErr)
+			}
+
+			// If labels are expected, fetch the instance and validate the labels.
+			if tc.expectedLabels != nil {
+				instance := &computev1alpha.Instance{}
+				if err := cl.Get(context.Background(), tc.req.NamespacedName, instance); err != nil {
+					t.Fatalf("failed to get instance: %v", err)
+				}
+				assert.Equal(t, tc.expectedLabels, instance.Labels)
+			}
+		})
+	}
+}

--- a/internal/controller/workload_controller.go
+++ b/internal/controller/workload_controller.go
@@ -398,6 +398,9 @@ func (r *WorkloadReconciler) getDeploymentsForWorkload(
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: workload.Namespace,
 					Name:      deploymentName,
+					Labels: map[string]string{
+						computev1alpha.WorkloadUIDLabel: string(workload.UID),
+					},
 					Finalizers: []string{
 						workloadControllerFinalizer,
 					},


### PR DESCRIPTION
The primary use of these labels is to support portal functionality. An `Instance` reconciler has been introduced due to those resources currently being created by `infra-provider-gcp` as instances are provisioned. This was found to be a more straight forward solution than adding a webhook, as the current controller-runtime libraries expect a webhook to be registered for each individual type. 

As part of https://github.com/datum-cloud/enhancements/issues/28, this reconciler will be substantially modified, or removed.
