### PR TITLE
chore: automate software builds

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,13 @@
+name: Publish Docker Image
+
+on:
+  push:
+  release:
+    types: ['published']
+
+jobs:
+  publish:
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.0.0
+    with:
+      image-name: workload-operator
+    secrets: inherit


### PR DESCRIPTION
Creates a new GitHub action workflow that will publish containers for the workload operator image.