### PR TITLE
bug: Wire through annotations and labels from the desired deployment 

### DIFF
--- a/internal/controller/workload_controller.go
+++ b/internal/controller/workload_controller.go
@@ -174,6 +174,8 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				logger.Info("updating deployment", "deployment_name", deployment.Name)
 			}
 
+			deployment.Annotations = desiredDeployment.Annotations
+			deployment.Labels = desiredDeployment.Labels
 			deployment.Spec = desiredDeployment.Spec
 			return nil
 		})


### PR DESCRIPTION
This is a fix to correctly apply the labels for WorkloadDeployment resources introduced in https://github.com/datum-cloud/workload-operator/pull/9.

The test framework hasn't been set up for this yet. I'd expect to cover this with a chainsaw test in the future.