### PR TITLE
Add resource metrics

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../resource-metrics
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - ../webhook

--- a/config/resource-metrics/general.yaml
+++ b/config/resource-metrics/general.yaml
@@ -1,0 +1,20 @@
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    # Creates a generic metric for all resources
+    - groupVersionKind:
+        group: compute.datumapis.com
+        kind: "*"
+        version: "*"
+      metricNamePrefix: "datum_cloud_resource"
+      labelsFromPath:
+        namespace: [metadata, namespace]
+        name: [metadata, name]
+      metrics:
+        - name: "info"
+          help: "Information about the resource"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                uid: [metadata, uid]

--- a/config/resource-metrics/instances.yaml
+++ b/config/resource-metrics/instances.yaml
@@ -1,0 +1,41 @@
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: compute.datumapis.com
+        kind: Instance
+        version: v1alpha
+      metricNamePrefix: "instance"
+      labelsFromPath:
+        namespace: [metadata, namespace]
+        name: [metadata, name]
+      metrics:
+        - name: "info"
+          help: "Information about instance"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                uid: [metadata, uid]
+                compute_datumapis_com_workload_deployment_uid: [metadata, labels, compute_datumapis_com_workload_deployment_uid]
+                compute_datumapis_com_workload_uid: [metadata, labels, compute_datumapis_com_workload_uid]
+        - name: "status_condition"
+          help: "The current status conditions of the instance"
+          each:
+            type: Gauge
+            gauge:
+              path: [status, conditions]
+              labelsFromPath:
+                condition: [type]
+                reason: [reason]
+                status: [status]
+              valueFrom: [status]
+        - name: "network_interface_info"
+          help: "Information about instance network interfaces"
+          each:
+            type: Info
+            info:
+              path: [status, networkInterfaces]
+              labelsFromPath:
+                network_ip: [assignments, networkIP]
+                external_ip: [assignments, externalIP]

--- a/config/resource-metrics/instances.yaml
+++ b/config/resource-metrics/instances.yaml
@@ -5,7 +5,7 @@ spec:
         group: compute.datumapis.com
         kind: Instance
         version: v1alpha
-      metricNamePrefix: "instance"
+      metricNamePrefix: "datum_cloud_compute_instance"
       labelsFromPath:
         namespace: [metadata, namespace]
         name: [metadata, name]

--- a/config/resource-metrics/kustomization.yaml
+++ b/config/resource-metrics/kustomization.yaml
@@ -8,6 +8,7 @@ configMapGenerator:
         telemetry.datumapis.com/resource-metrics-config: "true"
 
     files:
+      - general.yaml
       - instances.yaml
       - workload-deployments.yaml
       - workloads.yaml

--- a/config/resource-metrics/kustomization.yaml
+++ b/config/resource-metrics/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+  - name: workload-services-metrics
+    options:
+      labels:
+        telemetry.datumapis.com/resource-metrics-config: "true"
+
+    files:
+      - instances.yaml
+      - workload-deployments.yaml
+      - workloads.yaml

--- a/config/resource-metrics/workload-deployments.yaml
+++ b/config/resource-metrics/workload-deployments.yaml
@@ -1,0 +1,31 @@
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: compute.datumapis.com
+        kind: WorkloadDeployment
+        version: v1alpha
+      metricNamePrefix: "workload_deployment"
+      labelsFromPath:
+        namespace: [metadata, namespace]
+        name: [metadata, name]
+      metrics:
+        - name: "info"
+          help: "Information about workload deployment"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                uid: [metadata, uid]
+                compute_datumapis_com_workload_uid: [metadata, labels, compute_datumapis_com_workload_uid]
+        - name: "status_condition"
+          help: "The current status conditions of the workload deployment"
+          each:
+            type: Gauge
+            gauge:
+              path: [status, conditions]
+              labelsFromPath:
+                condition: [type]
+                reason: [reason]
+                status: [status]
+              valueFrom: [status]

--- a/config/resource-metrics/workload-deployments.yaml
+++ b/config/resource-metrics/workload-deployments.yaml
@@ -5,7 +5,7 @@ spec:
         group: compute.datumapis.com
         kind: WorkloadDeployment
         version: v1alpha
-      metricNamePrefix: "workload_deployment"
+      metricNamePrefix: "datum_cloud_compute_workload_deployment"
       labelsFromPath:
         namespace: [metadata, namespace]
         name: [metadata, name]

--- a/config/resource-metrics/workloads.yaml
+++ b/config/resource-metrics/workloads.yaml
@@ -5,7 +5,7 @@ spec:
         group: compute.datumapis.com
         kind: Workload
         version: v1alpha
-      metricNamePrefix: "workload"
+      metricNamePrefix: "datum_cloud_compute_workload"
       labelsFromPath:
         namespace: [metadata, namespace]
         name: [metadata, name]

--- a/config/resource-metrics/workloads.yaml
+++ b/config/resource-metrics/workloads.yaml
@@ -1,0 +1,30 @@
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: compute.datumapis.com
+        kind: Workload
+        version: v1alpha
+      metricNamePrefix: "workload"
+      labelsFromPath:
+        namespace: [metadata, namespace]
+        name: [metadata, name]
+      metrics:
+        - name: "info"
+          help: "Information about workload"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                uid: [metadata, uid]
+        - name: "status_condition"
+          help: "The current status conditions of the workload"
+          each:
+            type: Gauge
+            gauge:
+              path: [status, conditions]
+              labelsFromPath:
+                condition: [type]
+                reason: [reason]
+                status: [status]
+              valueFrom: [status]


### PR DESCRIPTION
Adds the necessary kube-state-metrics configuration to support collecting metrics for the custom resources exposed by this operator.