### PR TITLE
chore: output error from mutating resource

### DIFF
--- a/internal/controller/workload_controller.go
+++ b/internal/controller/workload_controller.go
@@ -181,7 +181,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		})
 
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed mutating workload deployment")
+			return ctrl.Result{}, fmt.Errorf("failed mutating workload deployment: %w", err)
 		}
 
 		placementDeployments[deployment.Spec.PlacementName] = append(


### PR DESCRIPTION
Addresses an issue with swallowing errors from attempting to modify a resource. 