### PR TITLE
Adjust the resource-metrics kustomization to be a Component and not a Kustomization.

### DIFF
--- a/config/resource-metrics/kustomization.yaml
+++ b/config/resource-metrics/kustomization.yaml
@@ -1,5 +1,5 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
 
 configMapGenerator:
   - name: workload-services-metrics


### PR DESCRIPTION
This enables us to include the manifests as a component in a Flux Kustomization, and aligns with how these are defined in [network-services-operator](https://github.com/datum-cloud/network-services-operator/blob/main/config/resource-metrics/kustomization.yaml) today.