### PR TITLE
feat: use project from extra

### DIFF
--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -18,13 +17,13 @@ var _ webhook.Server = &clusterAwareWebhookServer{}
 
 func (s *clusterAwareWebhookServer) Register(path string, hook http.Handler) {
 	if h, ok := hook.(*admission.Webhook); ok {
-		h.WithContextFunc = func(ctx context.Context, req *http.Request) context.Context {
-			clusterName, err := url.QueryUnescape(req.PathValue("cluster_name"))
-			if err != nil {
-				return ctx
+		orig := h.Handler
+		h.Handler = admission.HandlerFunc(func(ctx context.Context, req admission.Request) admission.Response {
+			if c := clusterFromExtra(req.UserInfo.Extra); c != "" {
+				ctx = WithClusterName(ctx, c)
 			}
-			return WithClusterName(ctx, clusterName)
-		}
+			return orig.Handle(ctx, req)
+		})
 	}
 
 	path = fmt.Sprintf("/clusters/{cluster_name}%s", path)

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -18,9 +18,8 @@ func (s *clusterAwareWebhookServer) Register(path string, hook http.Handler) {
 	if h, ok := hook.(*admission.Webhook); ok {
 		orig := h.Handler
 		h.Handler = admission.HandlerFunc(func(ctx context.Context, req admission.Request) admission.Response {
-			if c := clusterFromExtra(req.UserInfo.Extra); c != "" {
-				ctx = WithClusterName(ctx, c)
-			}
+			c := clusterFromExtra(req.UserInfo.Extra)
+			ctx = WithClusterName(ctx, c)
 			return orig.Handle(ctx, req)
 		})
 	}

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -2,7 +2,6 @@ package webhook
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -25,8 +24,6 @@ func (s *clusterAwareWebhookServer) Register(path string, hook http.Handler) {
 			return orig.Handle(ctx, req)
 		})
 	}
-
-	path = fmt.Sprintf("/clusters/{cluster_name}%s", path)
 
 	s.Server.Register(path, hook)
 }

--- a/internal/webhook/util.go
+++ b/internal/webhook/util.go
@@ -1,0 +1,18 @@
+package webhook
+
+import authv1 "k8s.io/api/authentication/v1"
+
+const (
+	ExtraProjectKey    = "project"
+	ParentNameExtraKey = "iam.miloapis.com/parent-name"
+)
+
+func clusterFromExtra(extra map[string]authv1.ExtraValue) string {
+	if v, ok := extra[ExtraProjectKey]; ok && len(v) > 0 && v[0] != "" {
+		return v[0]
+	}
+	if v, ok := extra[ParentNameExtraKey]; ok && len(v) > 0 && v[0] != "" {
+		return v[0]
+	}
+	return ""
+}

--- a/internal/webhook/util.go
+++ b/internal/webhook/util.go
@@ -3,14 +3,10 @@ package webhook
 import authv1 "k8s.io/api/authentication/v1"
 
 const (
-	ExtraProjectKey    = "project"
 	ParentNameExtraKey = "iam.miloapis.com/parent-name"
 )
 
 func clusterFromExtra(extra map[string]authv1.ExtraValue) string {
-	if v, ok := extra[ExtraProjectKey]; ok && len(v) > 0 && v[0] != "" {
-		return v[0]
-	}
 	if v, ok := extra[ParentNameExtraKey]; ok && len(v) > 0 && v[0] != "" {
 		return v[0]
 	}


### PR DESCRIPTION
This pull request refactors how the webhook server determines the cluster context for incoming requests. The main change is to extract the cluster name from the `UserInfo.Extra` field in the admission request, rather than from the request path, and to set the cluster context accordingly. This simplifies the context propagation and removes dependencies on URL parsing.

**Cluster context extraction improvements:**

* Added a new utility function `clusterFromExtra` in `internal/webhook/util.go` to extract the cluster name from the `UserInfo.Extra` field, specifically using the key `iam.miloapis.com/parent-name`.
* Updated the `Register` method in `clusterAwareWebhookServer` (`internal/webhook/server.go`) to wrap the webhook handler and inject the cluster context based on `UserInfo.Extra`, replacing the previous logic that parsed the cluster name from the request path.
