### PR TITLE
chore: convert prometheus config to kustomize component

### DIFF
--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
 resources:
-- monitor.yaml
+  - monitor.yaml


### PR DESCRIPTION
## Summary
- Convert `config/prometheus/` from a regular kustomization to a kustomize Component
- Enables inclusion via the Flux Kustomization `components` list in the infra repo for ServiceMonitor deployment

## Context
The infra repo's Flux Kustomization deploys operators from `path: manager` with kustomize `components`. The prometheus directory needs `kind: Component` to be includable this way, enabling metrics scraping for the control plane component behavior dashboard.