### PR TITLE
fix: add metrics auth RBAC to rbac_deployment component

### DIFF
--- a/config/rbac_deployment/kustomization.yaml
+++ b/config/rbac_deployment/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Component
 resources:
   - leader_election_role.yaml
   - leader_election_role_binding.yaml
+  - metrics_auth_role.yaml
+  - metrics_auth_role_binding.yaml

--- a/config/rbac_deployment/metrics_auth_role.yaml
+++ b/config/rbac_deployment/metrics_auth_role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/config/rbac_deployment/metrics_auth_role_binding.yaml
+++ b/config/rbac_deployment/metrics_auth_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system


### PR DESCRIPTION
## Summary

- Add `metrics_auth_role.yaml` and `metrics_auth_role_binding.yaml` to the `config/rbac_deployment/` kustomize Component
- These grant the operator SA permission to create `tokenreviews` and `subjectaccessreviews`, which controller-runtime's metrics filter needs to validate bearer tokens from VMAgent

## Context

The `rbac_deployment` component is used by the infra repo's Flux Kustomization to deploy RBAC alongside the operator. The existing `config/rbac/` directory includes these files but is not used in the deployment path (`config/manager` + `config/rbac_deployment`).

Without this RBAC, the metrics filter returns 401 for all scrape requests because it cannot call the TokenReview API.

## Test plan

- [ ] Verify kustomize build succeeds with the component
- [ ] After infra PR datum-cloud/infra#1995 is merged, verify workload-operator metrics show `up` in VMAgent targets