### PR TITLE
Publish multi-arch (amd64 + arm64) container images

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,9 +11,10 @@ jobs:
       id-token: write
       contents: read
       packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.5.1
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.13.1
     with:
       image-name: workload-operator
+      platforms: linux/amd64,linux/arm64
     secrets: inherit
 
   publish-kustomize-bundles:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG GIT_TREE_STATE=unknown
+ARG BUILD_DATE=unknown
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -26,7 +30,13 @@ ENV GOCACHE=/root/.cache/go-build
 ENV GOTMPDIR=/root/.cache/go-build
 RUN --mount=type=cache,target=/go/pkg/mod/ \
   --mount=type=cache,target="/root/.cache/go-build" \
-  CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+  CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
+    -ldflags "-s -w \
+      -X main.version=${VERSION} \
+      -X main.gitCommit=${GIT_COMMIT} \
+      -X main.gitTreeState=${GIT_TREE_STATE} \
+      -X main.buildDate=${BUILD_DATE}" \
+    -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -44,6 +44,12 @@ var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 	codecs   = serializer.NewCodecFactory(scheme, serializer.EnableStrict)
+
+	// Build metadata, set via -ldflags at build time. See Dockerfile.
+	version      = "dev"
+	gitCommit    = "unknown"
+	gitTreeState = "unknown"
+	buildDate    = "unknown"
 )
 
 func init() {
@@ -80,6 +86,13 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	setupLog.Info("starting workload-operator",
+		"version", version,
+		"gitCommit", gitCommit,
+		"gitTreeState", gitTreeState,
+		"buildDate", buildDate,
+	)
 
 	var serverConfig config.WorkloadOperator
 	var configData []byte


### PR DESCRIPTION
## Summary

The published `ghcr.io/datum-cloud/workload-operator` image is currently built for `linux/amd64` only. That blocks anyone running the downstream e2e environments on Apple Silicon — Docker has to fall back to emulation, which is slow and unreliable.

This PR publishes the image for both `linux/amd64` and `linux/arm64` so the same image runs natively on both architectures. Pulling by tag continues to work exactly as before; consumers automatically get the right variant for their machine.

## Why it's fast

A previous attempt at this reportedly took 15+ minutes per build because the builder was running under emulation. This PR teaches the build to cross-compile natively instead, which is the standard fast path for pure-Go projects. Locally verified with `docker buildx`:

| Build | Wall-clock |
|---|---|
| Cold cache, both architectures | **~47s** |
| Warm cache, both architectures | **~7s** |

That's roughly the same as today's amd64-only build, with arm64 added effectively for free.

As a small bonus, the binary now records its version, git commit, git tree state, and build date, and logs them on startup — useful for debugging which image is actually running in a cluster.

## Backwards compatibility

- Image tags and the registry path are unchanged. Anything pulling `ghcr.io/datum-cloud/workload-operator:<tag>` continues to work and now transparently gets the right architecture.
- Flux's image-controller, image-updater, kubectl, and containerd all handle multi-architecture images natively — no consumer changes needed.
- Local `make docker-build` is unchanged and still produces a host-architecture image for development.
- This PR also picks up a newer version of the shared publish workflow (`datum-cloud/actions` v1.5.1 → v1.13.1), which slightly changes how non-release tags are formatted (e.g. branch and SHA tags are now prefixed with `v0.0.0-` so they're semver-compatible). Anything pinning the old branch/SHA tag formats may need a small follow-up.

## Test plan

- [ ] CI publish workflow runs green on a branch push and produces a multi-architecture manifest at `ghcr.io/datum-cloud/workload-operator:<branch-tag>`
- [ ] `docker buildx imagetools inspect ghcr.io/datum-cloud/workload-operator:<tag>` shows both `linux/amd64` and `linux/arm64`
- [ ] Pulling and running the image on an Apple Silicon machine works without emulation
- [ ] Operator startup log shows the stamped version/commit/build-date values

🤖 Generated with [Claude Code](https://claude.com/claude-code)