### PR TITLE
feat: add discovery context annotations for project-scoped resources

### DIFF
--- a/api/v1alpha/instance_types.go
+++ b/api/v1alpha/instance_types.go
@@ -433,6 +433,7 @@ type InstanceTemplateSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Project"
 
 // Instance is the Schema for the instances API
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/api/v1alpha/workload_types.go
+++ b/api/v1alpha/workload_types.go
@@ -89,6 +89,7 @@ type WorkloadGatewayStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Project"
 
 // Workload is the Schema for the workloads API
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/api/v1alpha/workloaddeployment_types.go
+++ b/api/v1alpha/workloaddeployment_types.go
@@ -67,6 +67,7 @@ const (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Project"
 
 // WorkloadDeployment is the Schema for the workloaddeployments API
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/config/base/crd/bases/compute.datumapis.com_instances.yaml
+++ b/config/base/crd/bases/compute.datumapis.com_instances.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.4
+    discovery.miloapis.com/parent-contexts: Project
   name: instances.compute.datumapis.com
 spec:
   group: compute.datumapis.com

--- a/config/base/crd/bases/compute.datumapis.com_workloaddeployments.yaml
+++ b/config/base/crd/bases/compute.datumapis.com_workloaddeployments.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.4
+    discovery.miloapis.com/parent-contexts: Project
   name: workloaddeployments.compute.datumapis.com
 spec:
   group: compute.datumapis.com

--- a/config/base/crd/bases/compute.datumapis.com_workloads.yaml
+++ b/config/base/crd/bases/compute.datumapis.com_workloads.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.4
+    discovery.miloapis.com/parent-contexts: Project
   name: workloads.compute.datumapis.com
 spec:
   group: compute.datumapis.com


### PR DESCRIPTION
## Summary

This PR adds `discovery.miloapis.com/parent-contexts: Project` annotations to all CRD manifests in the compute repository, and the corresponding `+kubebuilder:metadata:annotations` markers to the Go type definitions.

### What these annotations do

The Milo API server includes a discovery filter that uses `discovery.miloapis.com/parent-contexts` annotations on CRD metadata to determine which resources to surface in API discovery responses. When a client queries API discovery within a Project context (e.g., against a project's dedicated control plane), the filter returns only those resources annotated with `Project` as a parent context.

Without these annotations, compute resources would be invisible in discovery when clients query within a Project context.

### Affected CRDs

- `instances.compute.datumapis.com`
- `workloaddeployments.compute.datumapis.com`
- `workloads.compute.datumapis.com`

### Changes

- Added `discovery.miloapis.com/parent-contexts: Project` to `metadata.annotations` in all three CRD YAML files under `config/base/crd/bases/`
- Added `// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Project"` marker to the root Go types in `api/v1alpha/` so the annotation survives future `task generate` runs

## Test plan

- [ ] Verify CRD YAML annotations are present in `config/base/crd/bases/`
- [ ] Apply CRDs to a cluster connected to a Milo API server with the `DiscoveryContextFilter` feature gate enabled
- [ ] Confirm compute resources appear in API discovery when querying within a Project context
- [ ] Confirm compute resources are absent from discovery when querying outside a Project context (e.g., Platform context only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)