### PR TITLE
feat: webhook HA, security hardening, and RBAC naming cleanup

### DIFF
--- a/config/base/manager/manager.yaml
+++ b/config/base/manager/manager.yaml
@@ -21,6 +21,10 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -36,6 +40,7 @@ spec:
           protocol: TCP
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
             - "ALL"

--- a/config/base/manager/manager.yaml
+++ b/config/base/manager/manager.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: compute
+  name: compute-manager
   labels:
     control-plane: compute
     app.kubernetes.io/name: compute

--- a/config/components/controller_rbac/metrics_auth_role.yaml
+++ b/config/components/controller_rbac/metrics_auth_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: metrics-auth-role
+  name: compute-metrics-auth-role
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/config/components/controller_rbac/metrics_auth_role_binding.yaml
+++ b/config/components/controller_rbac/metrics_auth_role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: metrics-auth-rolebinding
+  name: compute-metrics-auth-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: metrics-auth-role
+  name: compute-metrics-auth-role
 subjects:
 - kind: ServiceAccount
   name: compute

--- a/config/components/controller_rbac/metrics_reader_role.yaml
+++ b/config/components/controller_rbac/metrics_reader_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: metrics-reader
+  name: compute-metrics-reader
 rules:
 - nonResourceURLs:
   - "/metrics"

--- a/config/components/controller_rbac/workload_editor_role.yaml
+++ b/config/components/controller_rbac/workload_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: compute
     app.kubernetes.io/managed-by: kustomize
-  name: workload-editor-role
+  name: compute-workload-editor-role
 rules:
 - apiGroups:
   - compute.datumapis.com

--- a/config/components/controller_rbac/workload_viewer_role.yaml
+++ b/config/components/controller_rbac/workload_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: compute
     app.kubernetes.io/managed-by: kustomize
-  name: workload-viewer-role
+  name: compute-workload-viewer-role
 rules:
 - apiGroups:
   - compute.datumapis.com

--- a/config/components/controller_rbac/workloaddeployment_editor_role.yaml
+++ b/config/components/controller_rbac/workloaddeployment_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: compute
     app.kubernetes.io/managed-by: kustomize
-  name: workloaddeployment-editor-role
+  name: compute-workloaddeployment-editor-role
 rules:
 - apiGroups:
   - compute.datumapis.com

--- a/config/components/controller_rbac/workloaddeployment_viewer_role.yaml
+++ b/config/components/controller_rbac/workloaddeployment_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: compute
     app.kubernetes.io/managed-by: kustomize
-  name: workloaddeployment-viewer-role
+  name: compute-workloaddeployment-viewer-role
 rules:
 - apiGroups:
   - compute.datumapis.com

--- a/config/components/high-availability/kustomization.yaml
+++ b/config/components/high-availability/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- pdb.yaml
+
+patches:
+- path: manager_replicas_patch.yaml

--- a/config/components/high-availability/manager_replicas_patch.yaml
+++ b/config/components/high-availability/manager_replicas_patch.yaml
@@ -4,3 +4,12 @@ metadata:
   name: compute-manager
 spec:
   replicas: 2
+  template:
+    spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            control-plane: compute

--- a/config/components/high-availability/manager_replicas_patch.yaml
+++ b/config/components/high-availability/manager_replicas_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: compute-manager
+spec:
+  replicas: 2

--- a/config/components/high-availability/pdb.yaml
+++ b/config/components/high-availability/pdb.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: compute-manager
+  labels:
+    control-plane: compute
+    app.kubernetes.io/name: compute
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: compute

--- a/config/overlays/single-cluster/kustomization.yaml
+++ b/config/overlays/single-cluster/kustomization.yaml
@@ -14,6 +14,7 @@ components:
   - ../../components/leader_election
   - ../../components/controller_rbac
   - ../../components/resource-metrics
+  - ../../components/high-availability
 
 patches:
 - path: webhookcainjection_patch.yaml


### PR DESCRIPTION
## Summary

- Renames the manager `Deployment` from `compute` to `compute-manager` to avoid ambiguity with the broader system name
- Adds a new `config/components/high-availability` kustomize component with:
  - `replicas: 2` — eliminates the single-replica webhook availability gap on pod restart
  - `PodDisruptionBudget` (`minAvailable: 1`) — prevents simultaneous eviction of both pods during node maintenance
  - `topologySpreadConstraints` (`kubernetes.io/hostname`, `DoNotSchedule`) — ensures the two replicas land on different nodes so a node failure or drain cannot take down both pods at once
- Wires the `high-availability` component into `config/overlays/single-cluster`
- Hardens the manager security context to the Kubernetes restricted pod security standard:
  - `seccompProfile: RuntimeDefault` at the pod level
  - `runAsUser/runAsGroup: 65532` pinned to match the distroless `nonroot` image `USER`
  - `readOnlyRootFilesystem: true` at the container level
- Prefixes all RBAC `ClusterRole` and `ClusterRoleBinding` names with `compute-` to prevent collisions with other controllers in the same cluster

Consumers that want a single replica (e.g. staging) simply omit the `high-availability` component from their overlay.

Closes #91

## Test plan

- [ ] `kustomize build config/overlays/single-cluster/` produces a `Deployment` named `compute-manager` with `replicas: 2`, a `PodDisruptionBudget` with `minAvailable: 1`, and `topologySpreadConstraints` on `kubernetes.io/hostname`
- [ ] `kustomize build config/base/manager/` still builds cleanly with `replicas: 1` and no PDB
- [ ] All `ClusterRole` and `ClusterRoleBinding` names in the build output are prefixed with `compute-`
- [ ] Deploy to a test cluster and verify both pods become `Ready` and the webhook remains available during a `kubectl rollout restart`
- [ ] Verify pods are scheduled on separate nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)