### PR TITLE
feat: add service catalog registration for Compute

### DIFF
--- a/config/components/service-catalog/kustomization.yaml
+++ b/config/components/service-catalog/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - service.yaml
+  - service-configuration.yaml

--- a/config/components/service-catalog/service-configuration.yaml
+++ b/config/components/service-catalog/service-configuration.yaml
@@ -1,0 +1,76 @@
+apiVersion: services.miloapis.com/v1alpha1
+kind: ServiceConfiguration
+metadata:
+  name: compute
+spec:
+  meters:
+  - billing:
+      consumedUnit: s
+      pricingUnit: h
+    description: CPU seconds consumed by a running instance.
+    displayName: Compute Instance CPU Seconds
+    measurement:
+      aggregation: Sum
+      unit: s
+    monitoredResourceTypes:
+    - compute.datumapis.com/Instance
+    name: compute.datumapis.com/instance/cpu-seconds
+  - billing:
+      consumedUnit: By.s
+      pricingUnit: GiBy.h
+    description: Memory byte-seconds consumed by a running instance.
+    displayName: Compute Instance Memory Seconds
+    measurement:
+      aggregation: Sum
+      unit: By.s
+    monitoredResourceTypes:
+    - compute.datumapis.com/Instance
+    name: compute.datumapis.com/instance/memory-seconds
+  - billing:
+      consumedUnit: '{cpu}'
+      pricingUnit: '{cpu}'
+    description: Number of vCPUs allocated to an instance.
+    displayName: Compute Instance CPU Allocated
+    measurement:
+      aggregation: Latest
+      unit: '{cpu}'
+    monitoredResourceTypes:
+    - compute.datumapis.com/Instance
+    name: compute.datumapis.com/instance/cpu-allocated
+  - billing:
+      consumedUnit: By
+      pricingUnit: GiBy
+    description: Bytes of memory allocated to an instance.
+    displayName: Compute Instance Memory Allocated
+    measurement:
+      aggregation: Latest
+      unit: By
+    monitoredResourceTypes:
+    - compute.datumapis.com/Instance
+    name: compute.datumapis.com/instance/memory-allocated
+  - billing:
+      consumedUnit: s
+      pricingUnit: h
+    description: Seconds the instance has been in a running state.
+    displayName: Compute Instance Uptime
+    measurement:
+      aggregation: Sum
+      unit: s
+    monitoredResourceTypes:
+    - compute.datumapis.com/Instance
+    name: compute.datumapis.com/instance/uptime-seconds
+  monitoredResourceTypes:
+  - description: A Unikraft virtual machine instance.
+    displayName: Compute Instance
+    gvk:
+      group: compute.datumapis.com
+      kind: Instance
+    labels:
+    - description: The region where the instance is running.
+      name: region
+    - description: The service tier of the instance.
+      name: tier
+    type: compute.datumapis.com/Instance
+  phase: Published
+  serviceRef:
+    name: compute

--- a/config/components/service-catalog/service.yaml
+++ b/config/components/service-catalog/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: compute
 spec:
   description: |
-    Unikraft-based compute instances offering low-latency virtual machine workloads. Provides CPU and memory resources billed by consumption.
+    Low-latency virtual machine workloads with CPU and memory resources billed by consumption.
   displayName: Compute
   owner:
     producerProjectRef:

--- a/config/components/service-catalog/service.yaml
+++ b/config/components/service-catalog/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: services.miloapis.com/v1alpha1
+kind: Service
+metadata:
+  name: compute
+spec:
+  description: |
+    Unikraft-based compute instances offering low-latency virtual machine workloads. Provides CPU and memory resources billed by consumption.
+  displayName: Compute
+  owner:
+    producerProjectRef:
+      name: datum-cloud
+  phase: Published
+  serviceName: compute.datumapis.com


### PR DESCRIPTION
## Summary

Adds the Compute service to the Datum Cloud service catalog so it can be discovered, configured, and billed through the platform. This includes the service registration and its metering configuration, which defines how CPU and memory consumption are tracked for instances.

Both resources are packaged as a Kustomize component so they can be consistently applied across environments.

Relates to https://github.com/datum-cloud/enhancements/issues/681.

## Test plan

- [ ] `kustomize build config/components/service-catalog` renders both resources without error
- [ ] Service and ServiceConfiguration are present and in Published phase when applied to milo