### PR TITLE
feat: integrate compute service with Milo quota system

### DIFF
--- a/api/v1alpha/instance_types.go
+++ b/api/v1alpha/instance_types.go
@@ -389,6 +389,17 @@ const (
 
 	// InstanceProgrammed indicates that the instance has been programmed
 	InstanceProgrammed = "Programmed"
+
+	// InstanceQuotaGranted indicates whether quota has been allocated for the instance
+	InstanceQuotaGranted = "QuotaGranted"
+)
+
+const (
+	InstanceQuotaGrantedReasonPendingEvaluation = "PendingEvaluation"
+	InstanceQuotaGrantedReasonQuotaAvailable    = "QuotaAvailable"
+	InstanceQuotaGrantedReasonQuotaExceeded     = "QuotaExceeded"
+	InstanceQuotaGrantedReasonValidationFailed  = "ValidationFailed"
+	InstanceProgrammedReasonPendingQuota        = "PendingQuota"
 )
 
 const (
@@ -451,7 +462,7 @@ type Instance struct {
 
 	// Status defines the current state of an Instance.
 	//
-	// +kubebuilder:default={conditions:{{type:"Programmed",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type:"Running",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type:"Ready",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}}
+	// +kubebuilder:default={conditions:{{type:"Programmed",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type:"Running",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type:"Ready",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type:"QuotaGranted",status:"Unknown",reason:"PendingEvaluation",message:"Waiting for quota evaluation",lastTransitionTime:"1970-01-01T00:00:00Z"}}}
 	Status InstanceStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha/workloaddeployment_types.go
+++ b/api/v1alpha/workloaddeployment_types.go
@@ -63,6 +63,9 @@ const (
 	// WorkloadDeploymentAvailable indicates that at least one instance has come
 	// online.
 	WorkloadDeploymentAvailable = "Available"
+
+	// WorkloadDeploymentReplicasReady indicates whether all desired replicas are ready.
+	WorkloadDeploymentReplicasReady = "ReplicasReady"
 )
 
 // +kubebuilder:object:root=true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,6 +35,7 @@ import (
 	computewebhook "go.datum.net/compute/internal/webhook"
 	computev1alphawebhooks "go.datum.net/compute/internal/webhook/v1alpha"
 	networkingv1alpha "go.datum.net/network-services-operator/api/v1alpha"
+	quotav1alpha1 "go.miloapis.com/milo/pkg/apis/quota/v1alpha1"
 	multiclusterproviders "go.miloapis.com/milo/pkg/multicluster-runtime"
 	milomulticluster "go.miloapis.com/milo/pkg/multicluster-runtime/milo"
 	// +kubebuilder:scaffold:imports
@@ -59,6 +60,7 @@ func init() {
 	utilruntime.Must(config.RegisterDefaults(scheme))
 	utilruntime.Must(computev1alpha.AddToScheme(scheme))
 	utilruntime.Must(networkingv1alpha.AddToScheme(scheme))
+	utilruntime.Must(quotav1alpha1.AddToScheme(scheme))
 
 	// +kubebuilder:scaffold:scheme
 }
@@ -186,7 +188,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "WorkloadDeploymentScheduler")
 		os.Exit(1)
 	}
-	if err = (&controller.InstanceReconciler{}).SetupWithManager(mgr); err != nil {
+	if err = (&controller.InstanceReconciler{}).SetupWithManager(mgr, deploymentCluster); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Instance")
 		os.Exit(1)
 	}

--- a/config/components/quota/grant-creation-policy.yaml
+++ b/config/components/quota/grant-creation-policy.yaml
@@ -1,0 +1,29 @@
+apiVersion: quota.miloapis.com/v1alpha1
+kind: GrantCreationPolicy
+metadata:
+  name: compute-default-quota
+spec:
+  trigger:
+    resource:
+      apiVersion: resourcemanager.miloapis.com/v1alpha1
+      kind: Project
+  target:
+    resourceGrantTemplate:
+      metadata:
+        generateName: compute-quota-
+        namespace: "{{trigger.metadata.namespace}}"
+      spec:
+        consumerRef:
+          apiGroup: resourcemanager.miloapis.com
+          kind: Project
+          name: "{{trigger.metadata.name}}"
+        allowances:
+          - resourceType: compute.datumapis.com/instances
+            buckets:
+              - amount: 10
+          - resourceType: compute.datumapis.com/vcpus
+            buckets:
+              - amount: 40000
+          - resourceType: compute.datumapis.com/memory
+            buckets:
+              - amount: 81920

--- a/config/components/quota/kustomization.yaml
+++ b/config/components/quota/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - resource-registrations.yaml
+  - grant-creation-policy.yaml

--- a/config/components/quota/resource-registrations.yaml
+++ b/config/components/quota/resource-registrations.yaml
@@ -1,0 +1,53 @@
+apiVersion: quota.miloapis.com/v1alpha1
+kind: ResourceRegistration
+metadata:
+  name: compute-instances
+spec:
+  resourceType: compute.datumapis.com/instances
+  type: Entity
+  consumerType:
+    apiGroup: resourcemanager.miloapis.com
+    kind: Project
+  baseUnit: instance
+  displayUnit: instance
+  unitConversionFactor: 1
+  claimingResources:
+    - apiGroup: compute.datumapis.com
+      kind: Instance
+  description: Total running instances per project
+---
+apiVersion: quota.miloapis.com/v1alpha1
+kind: ResourceRegistration
+metadata:
+  name: compute-vcpus
+spec:
+  resourceType: compute.datumapis.com/vcpus
+  type: Allocation
+  consumerType:
+    apiGroup: resourcemanager.miloapis.com
+    kind: Project
+  baseUnit: millicore
+  displayUnit: vCPU
+  unitConversionFactor: 1000
+  claimingResources:
+    - apiGroup: compute.datumapis.com
+      kind: Instance
+  description: Total vCPU allocation across instances in millicores
+---
+apiVersion: quota.miloapis.com/v1alpha1
+kind: ResourceRegistration
+metadata:
+  name: compute-memory
+spec:
+  resourceType: compute.datumapis.com/memory
+  type: Allocation
+  consumerType:
+    apiGroup: resourcemanager.miloapis.com
+    kind: Project
+  baseUnit: MiB
+  displayUnit: MiB
+  unitConversionFactor: 1
+  claimingResources:
+    - apiGroup: compute.datumapis.com
+      kind: Instance
+  description: Total memory allocation across instances in MiB

--- a/internal/controller/instance_controller.go
+++ b/internal/controller/instance_controller.go
@@ -7,12 +7,20 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	ctrlsource "sigs.k8s.io/controller-runtime/pkg/source"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mccontext "sigs.k8s.io/multicluster-runtime/pkg/context"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
@@ -20,16 +28,29 @@ import (
 
 	computev1alpha "go.datum.net/compute/api/v1alpha"
 	networkingv1alpha "go.datum.net/network-services-operator/api/v1alpha"
+	quotav1alpha1 "go.miloapis.com/milo/pkg/apis/quota/v1alpha1"
+
+	"go.datum.net/compute/internal/controller/instancecontrol"
 )
+
+const instanceQuotaFinalizer = "quota.compute.datumapis.com/claim-cleanup"
+
+// clusterGetter is the subset of mcmanager.Manager used by InstanceReconciler.
+// Keeping it narrow allows unit tests to substitute a minimal fake.
+type clusterGetter interface {
+	GetCluster(ctx context.Context, clusterName string) (cluster.Cluster, error)
+}
 
 // InstanceReconciler reconciles an Instance object
 type InstanceReconciler struct {
-	mgr mcmanager.Manager
+	mgr               clusterGetter
+	managementCluster cluster.Cluster
 }
 
 // +kubebuilder:rbac:groups=compute.datumapis.com,resources=instances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=compute.datumapis.com,resources=instances/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=compute.datumapis.com,resources=instances/finalizers,verbs=update
+// +kubebuilder:rbac:groups=quota.miloapis.com,resources=resourceclaims,verbs=get;list;watch;create;delete
 
 func (r *InstanceReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (_ ctrl.Result, err error) {
 	logger := log.FromContext(ctx)
@@ -51,13 +72,212 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req mcreconcile.Requ
 	logger.Info("reconciling instance")
 	defer logger.Info("reconcile complete")
 
-	if changed, err := r.reconcileInstanceReadyCondition(ctx, cl.GetClient(), &instance, r.checkForNetworkCreationFailure); err != nil {
+	if !instance.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(&instance, instanceQuotaFinalizer) {
+			claimName := fmt.Sprintf("%s--%s", instance.Namespace, instance.Name)
+			var claim quotav1alpha1.ResourceClaim
+			if err := r.managementCluster.GetClient().Get(ctx, client.ObjectKey{Namespace: instance.Namespace, Name: claimName}, &claim); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return ctrl.Result{}, fmt.Errorf("failed getting resource claim for deletion: %w", err)
+				}
+			} else {
+				if err := r.managementCluster.GetClient().Delete(ctx, &claim); client.IgnoreNotFound(err) != nil {
+					return ctrl.Result{}, fmt.Errorf("failed deleting resource claim: %w", err)
+				}
+			}
+
+			controllerutil.RemoveFinalizer(&instance, instanceQuotaFinalizer)
+			if err := cl.GetClient().Update(ctx, &instance); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed removing quota finalizer: %w", err)
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(&instance, instanceQuotaFinalizer) {
+		controllerutil.AddFinalizer(&instance, instanceQuotaFinalizer)
+		if err := cl.GetClient().Update(ctx, &instance); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed adding quota finalizer: %w", err)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	grantedCondition, err := r.reconcileQuotaClaim(ctx, req.ClusterName, &instance)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed reconciling quota claim: %w", err)
+	}
+
+	statusChanged := false
+
+	switch {
+	case grantedCondition == nil || (grantedCondition.Status == metav1.ConditionFalse && grantedCondition.Reason == quotav1alpha1.ResourceClaimPendingReason):
+		statusChanged = apimeta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:               computev1alpha.InstanceQuotaGranted,
+			Status:             metav1.ConditionUnknown,
+			Reason:             computev1alpha.InstanceQuotaGrantedReasonPendingEvaluation,
+			Message:            "Waiting for quota evaluation",
+			ObservedGeneration: instance.Generation,
+		})
+
+	case grantedCondition.Status == metav1.ConditionTrue:
+		statusChanged = apimeta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:               computev1alpha.InstanceQuotaGranted,
+			Status:             metav1.ConditionTrue,
+			Reason:             computev1alpha.InstanceQuotaGrantedReasonQuotaAvailable,
+			Message:            grantedCondition.Message,
+			ObservedGeneration: instance.Generation,
+		})
+
+	case grantedCondition.Status == metav1.ConditionFalse:
+		reason := computev1alpha.InstanceQuotaGrantedReasonQuotaExceeded
+		if grantedCondition.Reason == quotav1alpha1.ResourceClaimValidationFailedReason {
+			reason = computev1alpha.InstanceQuotaGrantedReasonValidationFailed
+		}
+		statusChanged = apimeta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:               computev1alpha.InstanceQuotaGranted,
+			Status:             metav1.ConditionFalse,
+			Reason:             reason,
+			Message:            grantedCondition.Message,
+			ObservedGeneration: instance.Generation,
+		})
+	}
+
+	readyChanged, err := r.reconcileInstanceReadyCondition(ctx, cl.GetClient(), &instance, r.checkForNetworkCreationFailure)
+	if err != nil {
 		return ctrl.Result{}, err
-	} else if changed {
-		return ctrl.Result{}, cl.GetClient().Status().Update(ctx, &instance)
+	}
+
+	if statusChanged || readyChanged {
+		if err := cl.GetClient().Status().Update(ctx, &instance); err != nil {
+			return ctrl.Result{}, err
+		}
+		// Return after the status update so that the next reconcile sees the
+		// updated QuotaGranted condition before attempting spec changes.
+		return ctrl.Result{}, nil
+	}
+
+	// Remove the quota scheduling gate once QuotaGranted=True is persisted.
+	quotaGrantedCond := apimeta.FindStatusCondition(instance.Status.Conditions, computev1alpha.InstanceQuotaGranted)
+	if quotaGrantedCond != nil && quotaGrantedCond.Status == metav1.ConditionTrue {
+		if instance.Spec.Controller != nil {
+			newGates := make([]computev1alpha.SchedulingGate, 0, len(instance.Spec.Controller.SchedulingGates))
+			gateRemoved := false
+			for _, gate := range instance.Spec.Controller.SchedulingGates {
+				if gate.Name == instancecontrol.QuotaSchedulingGate.String() {
+					gateRemoved = true
+					continue
+				}
+				newGates = append(newGates, gate)
+			}
+			if gateRemoved {
+				patch := client.MergeFrom(instance.DeepCopy())
+				instance.Spec.Controller.SchedulingGates = newGates
+				if err := cl.GetClient().Patch(ctx, &instance, patch); err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed patching quota scheduling gate: %w", err)
+				}
+			}
+		}
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *InstanceReconciler) reconcileQuotaClaim(ctx context.Context, clusterName string, instance *computev1alpha.Instance) (*metav1.Condition, error) {
+	logger := log.FromContext(ctx)
+
+	claimName := fmt.Sprintf("%s--%s", instance.Namespace, instance.Name)
+
+	requests := []quotav1alpha1.ResourceRequest{
+		{
+			ResourceType: "compute.datumapis.com/instances",
+			Amount:       1,
+		},
+	}
+
+	cpuMillicores, memMiB, resolved := resolveInstanceResources(instance)
+	if !resolved {
+		logger.Info("unable to resolve resource amounts from instance spec, claiming instance count only")
+	} else {
+		requests = append(requests,
+			quotav1alpha1.ResourceRequest{
+				ResourceType: "compute.datumapis.com/vcpus",
+				Amount:       cpuMillicores,
+			},
+			quotav1alpha1.ResourceRequest{
+				ResourceType: "compute.datumapis.com/memory",
+				Amount:       memMiB,
+			},
+		)
+	}
+
+	desired := &quotav1alpha1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      claimName,
+			Namespace: instance.Namespace,
+		},
+		Spec: quotav1alpha1.ResourceClaimSpec{
+			ConsumerRef: quotav1alpha1.ConsumerRef{
+				APIGroup: "resourcemanager.miloapis.com",
+				Kind:     "Project",
+				Name:     clusterName,
+			},
+			ResourceRef: quotav1alpha1.UnversionedObjectReference{
+				APIGroup:  "compute.datumapis.com",
+				Kind:      "Instance",
+				Name:      instance.Name,
+				Namespace: instance.Namespace,
+			},
+			Requests: requests,
+		},
+	}
+
+	var existing quotav1alpha1.ResourceClaim
+	if err := r.managementCluster.GetClient().Get(ctx, client.ObjectKey{Namespace: desired.Namespace, Name: desired.Name}, &existing); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed getting resource claim: %w", err)
+		}
+		if err := r.managementCluster.GetClient().Create(ctx, desired); err != nil {
+			return nil, fmt.Errorf("failed creating resource claim: %w", err)
+		}
+		return nil, nil
+	}
+
+	grantedCondition := apimeta.FindStatusCondition(existing.Status.Conditions, quotav1alpha1.ResourceClaimGranted)
+	return grantedCondition, nil
+}
+
+func resolveInstanceResources(instance *computev1alpha.Instance) (cpuMillicores int64, memMiB int64, resolved bool) {
+	rt := instance.Spec.Runtime
+	if rt.Sandbox != nil {
+		var totalCPU resource.Quantity
+		var totalMem resource.Quantity
+		allSet := true
+		for _, c := range rt.Sandbox.Containers {
+			if c.Resources == nil || c.Resources.Limits == nil {
+				allSet = false
+				break
+			}
+			cpu, hasCPU := c.Resources.Limits[corev1.ResourceCPU]
+			mem, hasMem := c.Resources.Limits[corev1.ResourceMemory]
+			if !hasCPU || !hasMem {
+				allSet = false
+				break
+			}
+			totalCPU.Add(cpu)
+			totalMem.Add(mem)
+		}
+		if !allSet || len(rt.Sandbox.Containers) == 0 {
+			return 0, 0, false
+		}
+		return totalCPU.MilliValue(), totalMem.Value() / (1024 * 1024), true
+	}
+
+	cpu, hasCPU := rt.Resources.Requests[corev1.ResourceCPU]
+	mem, hasMem := rt.Resources.Requests[corev1.ResourceMemory]
+	if !hasCPU || !hasMem {
+		return 0, 0, false
+	}
+	return cpu.MilliValue(), mem.Value() / (1024 * 1024), true
 }
 
 // networkFailureChecker is a function that checks if a network creation failure
@@ -73,6 +293,33 @@ func (r *InstanceReconciler) reconcileInstanceReadyCondition(
 ) (changed bool, err error) {
 	logger := log.FromContext(ctx)
 
+	quotaGrantedCondition := apimeta.FindStatusCondition(instance.Status.Conditions, computev1alpha.InstanceQuotaGranted)
+	if quotaGrantedCondition != nil && quotaGrantedCondition.Status == metav1.ConditionFalse {
+		msg := quotaGrantedCondition.Message
+		changed = apimeta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:               computev1alpha.InstanceProgrammed,
+			Status:             metav1.ConditionFalse,
+			Reason:             computev1alpha.InstanceProgrammedReasonPendingQuota,
+			Message:            msg,
+			ObservedGeneration: instance.Generation,
+		})
+		changed = apimeta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:               computev1alpha.InstanceRunning,
+			Status:             metav1.ConditionFalse,
+			Reason:             computev1alpha.InstanceProgrammedReasonPendingQuota,
+			Message:            msg,
+			ObservedGeneration: instance.Generation,
+		}) || changed
+		changed = apimeta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:               computev1alpha.InstanceReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             computev1alpha.InstanceProgrammedReasonPendingQuota,
+			Message:            msg,
+			ObservedGeneration: instance.Generation,
+		}) || changed
+		return changed, nil
+	}
+
 	readyCondition := apimeta.FindStatusCondition(instance.Status.Conditions, computev1alpha.InstanceReady)
 	if readyCondition == nil {
 		readyCondition = &metav1.Condition{
@@ -87,10 +334,6 @@ func (r *InstanceReconciler) reconcileInstanceReadyCondition(
 	}
 
 	if instance.Spec.Controller != nil && len(instance.Spec.Controller.SchedulingGates) > 0 {
-		// Update Ready condition to False, Reason to "SchedulingGatesPresent"
-		// and Message to "Scheduling gates present"
-
-		// Collect a list of scheduling gate names
 		var schedulingGateNames []string
 		for _, gate := range instance.Spec.Controller.SchedulingGates {
 			schedulingGateNames = append(schedulingGateNames, gate.Name)
@@ -164,7 +407,6 @@ func (r *InstanceReconciler) checkForNetworkCreationFailure(ctx context.Context,
 		return false, "", fmt.Errorf("instance is not owned by a workload deployment")
 	}
 
-	// Load the WorkloadDeployment for the instance
 	var workloadDeployment computev1alpha.WorkloadDeployment
 	workloadDeploymentObjectKey := client.ObjectKey{
 		Namespace: instance.Namespace,
@@ -195,9 +437,37 @@ func (r *InstanceReconciler) checkForNetworkCreationFailure(ctx context.Context,
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *InstanceReconciler) SetupWithManager(mgr mcmanager.Manager) error {
+func (r *InstanceReconciler) SetupWithManager(mgr mcmanager.Manager, managementCluster cluster.Cluster) error {
 	r.mgr = mgr
+	r.managementCluster = managementCluster
+
+	// Watch ResourceClaim objects on the management cluster directly, bypassing
+	// the multicluster clusterInjectingQueue which would overwrite ClusterName.
+	// Using ctrlsource.TypedKind lets the handler produce mcreconcile.Request
+	// values with the correct ClusterName taken from claim.Spec.ConsumerRef.Name.
+	claimSource := ctrlsource.TypedKind(
+		managementCluster.GetCache(),
+		&quotav1alpha1.ResourceClaim{},
+		handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, claim *quotav1alpha1.ResourceClaim) []mcreconcile.Request {
+			if claim.Spec.ResourceRef.Kind != "Instance" || claim.Spec.ResourceRef.APIGroup != "compute.datumapis.com" {
+				return nil
+			}
+			return []mcreconcile.Request{
+				{
+					Request: reconcile.Request{
+						NamespacedName: types.NamespacedName{
+							Name:      claim.Spec.ResourceRef.Name,
+							Namespace: claim.Spec.ResourceRef.Namespace,
+						},
+					},
+					ClusterName: claim.Spec.ConsumerRef.Name,
+				},
+			}
+		}),
+	)
+
 	return mcbuilder.ControllerManagedBy(mgr).
 		For(&computev1alpha.Instance{}, mcbuilder.WithEngageWithLocalCluster(false)).
+		WatchesRawSource(claimSource).
 		Complete(r)
 }

--- a/internal/controller/instance_controller_test.go
+++ b/internal/controller/instance_controller_test.go
@@ -67,10 +67,10 @@ func newTestScheme(t *testing.T) *runtime.Scheme {
 }
 
 // reconcileRequest builds a multicluster reconcile.Request for a given instance.
-func reconcileRequest(clusterName, namespace, name string) mcreconcile.Request {
+func reconcileRequest(namespace, name string) mcreconcile.Request {
 	return mcreconcile.Request{
 		Request:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
-		ClusterName: clusterName,
+		ClusterName: "test-project",
 	}
 }
 
@@ -620,7 +620,7 @@ func TestReconcileQuota(t *testing.T) {
 		r, projectClient, _ := newReconciler(t, []client.Object{instance, makeDeployment()}, []client.Object{claim})
 
 		// First reconcile: sets QuotaGranted=True in status, returns early.
-		_, err := r.Reconcile(context.Background(), reconcileRequest(clusterName, namespace, instanceName))
+		_, err := r.Reconcile(context.Background(), reconcileRequest(namespace, instanceName))
 		require.NoError(t, err)
 
 		var updated computev1alpha.Instance
@@ -632,7 +632,7 @@ func TestReconcileQuota(t *testing.T) {
 		assert.Equal(t, computev1alpha.InstanceQuotaGrantedReasonQuotaAvailable, quotaCond.Reason)
 
 		// Second reconcile: status is already set, so removes the scheduling gate.
-		_, err = r.Reconcile(context.Background(), reconcileRequest(clusterName, namespace, instanceName))
+		_, err = r.Reconcile(context.Background(), reconcileRequest(namespace, instanceName))
 		require.NoError(t, err)
 
 		require.NoError(t, projectClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: instanceName}, &updated))
@@ -656,7 +656,7 @@ func TestReconcileQuota(t *testing.T) {
 
 		r, projectClient, _ := newReconciler(t, []client.Object{instance, makeDeployment()}, []client.Object{claim})
 
-		_, err := r.Reconcile(context.Background(), reconcileRequest(clusterName, namespace, instanceName))
+		_, err := r.Reconcile(context.Background(), reconcileRequest(namespace, instanceName))
 		require.NoError(t, err)
 
 		var updated computev1alpha.Instance
@@ -694,7 +694,7 @@ func TestReconcileQuota(t *testing.T) {
 		r, projectClient, mgmtClient := newReconciler(t, []client.Object{instance, makeDeployment()}, []client.Object{claim})
 
 		// First reconcile with denied claim.
-		_, err := r.Reconcile(context.Background(), reconcileRequest(clusterName, namespace, instanceName))
+		_, err := r.Reconcile(context.Background(), reconcileRequest(namespace, instanceName))
 		require.NoError(t, err)
 
 		var blocked computev1alpha.Instance
@@ -718,7 +718,7 @@ func TestReconcileQuota(t *testing.T) {
 		require.NoError(t, mgmtClient.Status().Update(context.Background(), &existingClaim))
 
 		// Second reconcile should see granted claim and update status.
-		_, err = r.Reconcile(context.Background(), reconcileRequest(clusterName, namespace, instanceName))
+		_, err = r.Reconcile(context.Background(), reconcileRequest(namespace, instanceName))
 		require.NoError(t, err)
 
 		var recovered computev1alpha.Instance
@@ -728,7 +728,7 @@ func TestReconcileQuota(t *testing.T) {
 		assert.Equal(t, metav1.ConditionTrue, quotaCond.Status)
 
 		// Third reconcile removes the gate (status is already true, no more status write needed).
-		_, err = r.Reconcile(context.Background(), reconcileRequest(clusterName, namespace, instanceName))
+		_, err = r.Reconcile(context.Background(), reconcileRequest(namespace, instanceName))
 		require.NoError(t, err)
 
 		require.NoError(t, projectClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: instanceName}, &recovered))
@@ -754,7 +754,7 @@ func TestReconcileQuota(t *testing.T) {
 
 		r, projectClient, mgmtClient := newReconciler(t, []client.Object{instance}, []client.Object{claim})
 
-		_, err := r.Reconcile(context.Background(), reconcileRequest(clusterName, namespace, instanceName))
+		_, err := r.Reconcile(context.Background(), reconcileRequest(namespace, instanceName))
 		require.NoError(t, err)
 
 		// Claim should have been deleted from the management cluster.

--- a/internal/controller/instance_controller_test.go
+++ b/internal/controller/instance_controller_test.go
@@ -66,13 +66,6 @@ func newTestScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
-// reconcileRequest builds a multicluster reconcile.Request for a given instance.
-func reconcileRequest(name string) mcreconcile.Request {
-	return mcreconcile.Request{
-		Request:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: name}},
-		ClusterName: "test-project",
-	}
-}
 
 func TestReconcileInstanceReadyCondition(t *testing.T) {
 
@@ -620,7 +613,7 @@ func TestReconcileQuota(t *testing.T) {
 		r, projectClient, _ := newReconciler(t, []client.Object{instance, makeDeployment()}, []client.Object{claim})
 
 		// First reconcile: sets QuotaGranted=True in status, returns early.
-		_, err := r.Reconcile(context.Background(), reconcileRequest(instanceName))
+		_, err := r.Reconcile(context.Background(), mcreconcile.Request{Request: reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: instanceName}}, ClusterName: clusterName})
 		require.NoError(t, err)
 
 		var updated computev1alpha.Instance
@@ -632,7 +625,7 @@ func TestReconcileQuota(t *testing.T) {
 		assert.Equal(t, computev1alpha.InstanceQuotaGrantedReasonQuotaAvailable, quotaCond.Reason)
 
 		// Second reconcile: status is already set, so removes the scheduling gate.
-		_, err = r.Reconcile(context.Background(), reconcileRequest(instanceName))
+		_, err = r.Reconcile(context.Background(), mcreconcile.Request{Request: reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: instanceName}}, ClusterName: clusterName})
 		require.NoError(t, err)
 
 		require.NoError(t, projectClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: instanceName}, &updated))
@@ -656,7 +649,7 @@ func TestReconcileQuota(t *testing.T) {
 
 		r, projectClient, _ := newReconciler(t, []client.Object{instance, makeDeployment()}, []client.Object{claim})
 
-		_, err := r.Reconcile(context.Background(), reconcileRequest(instanceName))
+		_, err := r.Reconcile(context.Background(), mcreconcile.Request{Request: reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: instanceName}}, ClusterName: clusterName})
 		require.NoError(t, err)
 
 		var updated computev1alpha.Instance
@@ -694,7 +687,7 @@ func TestReconcileQuota(t *testing.T) {
 		r, projectClient, mgmtClient := newReconciler(t, []client.Object{instance, makeDeployment()}, []client.Object{claim})
 
 		// First reconcile with denied claim.
-		_, err := r.Reconcile(context.Background(), reconcileRequest(instanceName))
+		_, err := r.Reconcile(context.Background(), mcreconcile.Request{Request: reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: instanceName}}, ClusterName: clusterName})
 		require.NoError(t, err)
 
 		var blocked computev1alpha.Instance
@@ -718,7 +711,7 @@ func TestReconcileQuota(t *testing.T) {
 		require.NoError(t, mgmtClient.Status().Update(context.Background(), &existingClaim))
 
 		// Second reconcile should see granted claim and update status.
-		_, err = r.Reconcile(context.Background(), reconcileRequest(instanceName))
+		_, err = r.Reconcile(context.Background(), mcreconcile.Request{Request: reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: instanceName}}, ClusterName: clusterName})
 		require.NoError(t, err)
 
 		var recovered computev1alpha.Instance
@@ -728,7 +721,7 @@ func TestReconcileQuota(t *testing.T) {
 		assert.Equal(t, metav1.ConditionTrue, quotaCond.Status)
 
 		// Third reconcile removes the gate (status is already true, no more status write needed).
-		_, err = r.Reconcile(context.Background(), reconcileRequest(instanceName))
+		_, err = r.Reconcile(context.Background(), mcreconcile.Request{Request: reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: instanceName}}, ClusterName: clusterName})
 		require.NoError(t, err)
 
 		require.NoError(t, projectClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: instanceName}, &recovered))
@@ -754,7 +747,7 @@ func TestReconcileQuota(t *testing.T) {
 
 		r, projectClient, mgmtClient := newReconciler(t, []client.Object{instance}, []client.Object{claim})
 
-		_, err := r.Reconcile(context.Background(), reconcileRequest(instanceName))
+		_, err := r.Reconcile(context.Background(), mcreconcile.Request{Request: reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: instanceName}}, ClusterName: clusterName})
 		require.NoError(t, err)
 
 		// Claim should have been deleted from the management cluster.

--- a/internal/controller/instance_controller_test.go
+++ b/internal/controller/instance_controller_test.go
@@ -66,7 +66,6 @@ func newTestScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
-
 func TestReconcileInstanceReadyCondition(t *testing.T) {
 
 	tests := []struct {

--- a/internal/controller/instance_controller_test.go
+++ b/internal/controller/instance_controller_test.go
@@ -2,16 +2,77 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	computev1alpha "go.datum.net/compute/api/v1alpha"
+	"go.datum.net/compute/internal/controller/instancecontrol"
+	quotav1alpha1 "go.miloapis.com/milo/pkg/apis/quota/v1alpha1"
 )
+
+// fakeCluster implements cluster.Cluster for testing using a fake client.
+type fakeCluster struct {
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+func (f *fakeCluster) GetHTTPClient() *http.Client                     { return nil }
+func (f *fakeCluster) GetConfig() *rest.Config                         { return nil }
+func (f *fakeCluster) GetCache() cache.Cache                           { return nil }
+func (f *fakeCluster) GetScheme() *runtime.Scheme                      { return f.scheme }
+func (f *fakeCluster) GetClient() client.Client                        { return f.client }
+func (f *fakeCluster) GetFieldIndexer() client.FieldIndexer            { return nil }
+func (f *fakeCluster) GetEventRecorderFor(string) record.EventRecorder { return nil }
+func (f *fakeCluster) GetRESTMapper() apimeta.RESTMapper               { return nil }
+func (f *fakeCluster) GetAPIReader() client.Reader                     { return f.client }
+func (f *fakeCluster) Start(context.Context) error                     { return nil }
+
+// fakeMCManager is a minimal multicluster manager that returns a single cluster.
+type fakeMCManager struct {
+	clusters map[string]cluster.Cluster
+}
+
+func (m *fakeMCManager) GetCluster(ctx context.Context, clusterName string) (cluster.Cluster, error) {
+	cl, ok := m.clusters[clusterName]
+	if !ok {
+		return nil, fmt.Errorf("cluster %q not found", clusterName)
+	}
+	return cl, nil
+}
+
+// newTestScheme builds a runtime.Scheme with the types needed for instance reconcile tests.
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, computev1alpha.AddToScheme(s))
+	require.NoError(t, quotav1alpha1.AddToScheme(s))
+	return s
+}
+
+// reconcileRequest builds a multicluster reconcile.Request for a given instance.
+func reconcileRequest(clusterName, namespace, name string) mcreconcile.Request {
+	return mcreconcile.Request{
+		Request:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+		ClusterName: clusterName,
+	}
+}
 
 func TestReconcileInstanceReadyCondition(t *testing.T) {
 
@@ -277,4 +338,439 @@ func TestReconcileInstanceReadyCondition(t *testing.T) {
 			assert.Equal(t, tt.expectedCondition.ObservedGeneration, readyCondition.ObservedGeneration)
 		})
 	}
+}
+
+func TestReconcileInstanceReadyConditionWithQuota(t *testing.T) {
+	tests := []struct {
+		name              string
+		instance          *computev1alpha.Instance
+		expectedChanged   bool
+		expectedCondition *metav1.Condition
+	}{
+		{
+			name: "quota denied blocks ready condition",
+			instance: &computev1alpha.Instance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-instance",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Status: computev1alpha.InstanceStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               computev1alpha.InstanceQuotaGranted,
+							Status:             metav1.ConditionFalse,
+							Reason:             computev1alpha.InstanceQuotaGrantedReasonQuotaExceeded,
+							Message:            "Quota exceeded for project",
+							LastTransitionTime: metav1.Now(),
+						},
+						{
+							Type:               computev1alpha.InstanceProgrammed,
+							Status:             metav1.ConditionTrue,
+							Reason:             computev1alpha.InstanceProgrammedReasonProgrammed,
+							Message:            "Instance has been programmed",
+							LastTransitionTime: metav1.Now(),
+						},
+						{
+							Type:               computev1alpha.InstanceRunning,
+							Status:             metav1.ConditionTrue,
+							Reason:             computev1alpha.InstanceRunningReasonRunning,
+							Message:            "Instance is running",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			expectedChanged: true,
+			expectedCondition: &metav1.Condition{
+				Type:    computev1alpha.InstanceReady,
+				Status:  metav1.ConditionFalse,
+				Reason:  computev1alpha.InstanceProgrammedReasonPendingQuota,
+				Message: "Quota exceeded for project",
+			},
+		},
+		{
+			name: "quota available does not block ready condition",
+			instance: &computev1alpha.Instance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-instance",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Status: computev1alpha.InstanceStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               computev1alpha.InstanceQuotaGranted,
+							Status:             metav1.ConditionTrue,
+							Reason:             computev1alpha.InstanceQuotaGrantedReasonQuotaAvailable,
+							Message:            "Quota allocated",
+							LastTransitionTime: metav1.Now(),
+						},
+						{
+							Type:               computev1alpha.InstanceProgrammed,
+							Status:             metav1.ConditionTrue,
+							Reason:             computev1alpha.InstanceProgrammedReasonProgrammed,
+							Message:            "Instance has been programmed",
+							LastTransitionTime: metav1.Now(),
+						},
+						{
+							Type:               computev1alpha.InstanceRunning,
+							Status:             metav1.ConditionTrue,
+							Reason:             computev1alpha.InstanceRunningReasonRunning,
+							Message:            "Instance is running",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			expectedChanged: true,
+			expectedCondition: &metav1.Condition{
+				Type:    computev1alpha.InstanceReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  computev1alpha.InstanceReadyReasonRunning,
+				Message: "Instance is ready",
+			},
+		},
+		{
+			name: "quota pending unknown does not block ready condition",
+			instance: &computev1alpha.Instance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-instance",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Status: computev1alpha.InstanceStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               computev1alpha.InstanceQuotaGranted,
+							Status:             metav1.ConditionUnknown,
+							Reason:             computev1alpha.InstanceQuotaGrantedReasonPendingEvaluation,
+							Message:            "Waiting for quota evaluation",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			expectedChanged: true,
+			expectedCondition: &metav1.Condition{
+				Type:    computev1alpha.InstanceReady,
+				Status:  metav1.ConditionFalse,
+				Reason:  computev1alpha.InstanceProgrammedReasonPendingProgramming,
+				Message: "Instance has not been programmed",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reconciler := &InstanceReconciler{}
+
+			noNetworkFailure := func(_ context.Context, _ client.Client, _ *computev1alpha.Instance) (bool, string, error) {
+				return false, "", nil
+			}
+
+			changed, err := reconciler.reconcileInstanceReadyCondition(
+				context.Background(),
+				nil,
+				tt.instance,
+				noNetworkFailure,
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedChanged, changed)
+
+			readyCondition := apimeta.FindStatusCondition(tt.instance.Status.Conditions, computev1alpha.InstanceReady)
+			require.NotNil(t, readyCondition)
+
+			assert.Equal(t, tt.expectedCondition.Type, readyCondition.Type)
+			assert.Equal(t, tt.expectedCondition.Status, readyCondition.Status)
+			assert.Equal(t, tt.expectedCondition.Reason, readyCondition.Reason)
+			assert.Equal(t, tt.expectedCondition.Message, readyCondition.Message)
+		})
+	}
+}
+
+// TestReconcileQuota tests the full Reconcile path for quota-related scenarios
+// by wiring up a fake project cluster client and a fake management cluster client.
+func TestReconcileQuota(t *testing.T) {
+	const (
+		clusterName  = "test-project"
+		namespace    = "default"
+		instanceName = "my-instance"
+	)
+
+	claimName := namespace + "--" + instanceName
+
+	const deploymentName = "my-deployment"
+
+	// makeDeployment builds a WorkloadDeployment that owns the test instance.
+	makeDeployment := func() *computev1alpha.WorkloadDeployment {
+		return &computev1alpha.WorkloadDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      deploymentName,
+				Namespace: namespace,
+				UID:       "test-uid",
+			},
+		}
+	}
+
+	// makeInstance creates a test Instance with an owner reference to the
+	// deployment so that checkForNetworkCreationFailure can look it up.
+	makeInstance := func(_ *runtime.Scheme, gates ...computev1alpha.SchedulingGate) *computev1alpha.Instance {
+		return &computev1alpha.Instance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       instanceName,
+				Namespace:  namespace,
+				Finalizers: []string{instanceQuotaFinalizer},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "compute.datumapis.com/v1alpha",
+						Kind:       "WorkloadDeployment",
+						Name:       deploymentName,
+						UID:        "test-uid",
+						Controller: func() *bool { b := true; return &b }(),
+					},
+				},
+			},
+			Spec: computev1alpha.InstanceSpec{
+				Controller: &computev1alpha.InstanceController{
+					SchedulingGates: gates,
+				},
+				Runtime: computev1alpha.InstanceRuntimeSpec{
+					Resources: computev1alpha.InstanceRuntimeResources{InstanceType: "d1-standard-2"},
+				},
+				NetworkInterfaces: []computev1alpha.InstanceNetworkInterface{},
+			},
+		}
+	}
+
+	makeClaim := func(_ *runtime.Scheme, granted metav1.ConditionStatus, reason string) *quotav1alpha1.ResourceClaim {
+		return &quotav1alpha1.ResourceClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      claimName,
+				Namespace: namespace,
+			},
+			Spec: quotav1alpha1.ResourceClaimSpec{
+				ConsumerRef: quotav1alpha1.ConsumerRef{
+					APIGroup: "resourcemanager.miloapis.com",
+					Kind:     "Project",
+					Name:     clusterName,
+				},
+				ResourceRef: quotav1alpha1.UnversionedObjectReference{
+					APIGroup:  "compute.datumapis.com",
+					Kind:      "Instance",
+					Name:      instanceName,
+					Namespace: namespace,
+				},
+				Requests: []quotav1alpha1.ResourceRequest{
+					{ResourceType: "compute.datumapis.com/instances", Amount: 1},
+				},
+			},
+			Status: quotav1alpha1.ResourceClaimStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               quotav1alpha1.ResourceClaimGranted,
+						Status:             granted,
+						Reason:             reason,
+						Message:            "test message",
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+		}
+	}
+
+	newReconciler := func(t *testing.T, projectObjs []client.Object, mgmtObjs []client.Object) (*InstanceReconciler, client.Client, client.Client) {
+		t.Helper()
+		s := newTestScheme(t)
+
+		projectClient := fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(projectObjs...).
+			WithStatusSubresource(&computev1alpha.Instance{}).
+			Build()
+
+		mgmtClient := fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(mgmtObjs...).
+			WithStatusSubresource(&quotav1alpha1.ResourceClaim{}).
+			Build()
+
+		mgr := &fakeMCManager{
+			clusters: map[string]cluster.Cluster{
+				clusterName: &fakeCluster{client: projectClient, scheme: s},
+			},
+		}
+
+		r := &InstanceReconciler{
+			mgr:               mgr,
+			managementCluster: &fakeCluster{client: mgmtClient, scheme: s},
+		}
+		return r, projectClient, mgmtClient
+	}
+
+	t.Run("quota granted flow: claim granted removes gate and sets QuotaGranted=True", func(t *testing.T) {
+		s := newTestScheme(t)
+		instance := makeInstance(s,
+			computev1alpha.SchedulingGate{Name: instancecontrol.NetworkSchedulingGate.String()},
+			computev1alpha.SchedulingGate{Name: instancecontrol.QuotaSchedulingGate.String()},
+		)
+		claim := makeClaim(s, metav1.ConditionTrue, quotav1alpha1.ResourceClaimGrantedReason)
+
+		r, projectClient, _ := newReconciler(t, []client.Object{instance, makeDeployment()}, []client.Object{claim})
+
+		// First reconcile: sets QuotaGranted=True in status, returns early.
+		_, err := r.Reconcile(context.Background(), reconcileRequest(clusterName, namespace, instanceName))
+		require.NoError(t, err)
+
+		var updated computev1alpha.Instance
+		require.NoError(t, projectClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: instanceName}, &updated))
+
+		quotaCond := apimeta.FindStatusCondition(updated.Status.Conditions, computev1alpha.InstanceQuotaGranted)
+		require.NotNil(t, quotaCond)
+		assert.Equal(t, metav1.ConditionTrue, quotaCond.Status)
+		assert.Equal(t, computev1alpha.InstanceQuotaGrantedReasonQuotaAvailable, quotaCond.Reason)
+
+		// Second reconcile: status is already set, so removes the scheduling gate.
+		_, err = r.Reconcile(context.Background(), reconcileRequest(clusterName, namespace, instanceName))
+		require.NoError(t, err)
+
+		require.NoError(t, projectClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: instanceName}, &updated))
+
+		hasQuotaGate := false
+		for _, g := range updated.Spec.Controller.SchedulingGates {
+			if g.Name == instancecontrol.QuotaSchedulingGate.String() {
+				hasQuotaGate = true
+			}
+		}
+		assert.False(t, hasQuotaGate, "QuotaSchedulingGate should have been removed")
+	})
+
+	t.Run("quota exceeded flow: conditions cascade to block Programmed/Running/Ready", func(t *testing.T) {
+		s := newTestScheme(t)
+		instance := makeInstance(s,
+			computev1alpha.SchedulingGate{Name: instancecontrol.NetworkSchedulingGate.String()},
+			computev1alpha.SchedulingGate{Name: instancecontrol.QuotaSchedulingGate.String()},
+		)
+		claim := makeClaim(s, metav1.ConditionFalse, quotav1alpha1.ResourceClaimDeniedReason)
+
+		r, projectClient, _ := newReconciler(t, []client.Object{instance, makeDeployment()}, []client.Object{claim})
+
+		_, err := r.Reconcile(context.Background(), reconcileRequest(clusterName, namespace, instanceName))
+		require.NoError(t, err)
+
+		var updated computev1alpha.Instance
+		require.NoError(t, projectClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: instanceName}, &updated))
+
+		quotaCond := apimeta.FindStatusCondition(updated.Status.Conditions, computev1alpha.InstanceQuotaGranted)
+		require.NotNil(t, quotaCond)
+		assert.Equal(t, metav1.ConditionFalse, quotaCond.Status)
+		assert.Equal(t, computev1alpha.InstanceQuotaGrantedReasonQuotaExceeded, quotaCond.Reason)
+
+		programmedCond := apimeta.FindStatusCondition(updated.Status.Conditions, computev1alpha.InstanceProgrammed)
+		require.NotNil(t, programmedCond)
+		assert.Equal(t, metav1.ConditionFalse, programmedCond.Status)
+		assert.Equal(t, computev1alpha.InstanceProgrammedReasonPendingQuota, programmedCond.Reason)
+
+		runningCond := apimeta.FindStatusCondition(updated.Status.Conditions, computev1alpha.InstanceRunning)
+		require.NotNil(t, runningCond)
+		assert.Equal(t, metav1.ConditionFalse, runningCond.Status)
+		assert.Equal(t, computev1alpha.InstanceProgrammedReasonPendingQuota, runningCond.Reason)
+
+		readyCond := apimeta.FindStatusCondition(updated.Status.Conditions, computev1alpha.InstanceReady)
+		require.NotNil(t, readyCond)
+		assert.Equal(t, metav1.ConditionFalse, readyCond.Status)
+		assert.Equal(t, computev1alpha.InstanceProgrammedReasonPendingQuota, readyCond.Reason)
+	})
+
+	t.Run("quota restored: denied claim updated to granted triggers gate removal", func(t *testing.T) {
+		s := newTestScheme(t)
+		instance := makeInstance(s,
+			computev1alpha.SchedulingGate{Name: instancecontrol.NetworkSchedulingGate.String()},
+			computev1alpha.SchedulingGate{Name: instancecontrol.QuotaSchedulingGate.String()},
+		)
+		claim := makeClaim(s, metav1.ConditionFalse, quotav1alpha1.ResourceClaimDeniedReason)
+
+		r, projectClient, mgmtClient := newReconciler(t, []client.Object{instance, makeDeployment()}, []client.Object{claim})
+
+		// First reconcile with denied claim.
+		_, err := r.Reconcile(context.Background(), reconcileRequest(clusterName, namespace, instanceName))
+		require.NoError(t, err)
+
+		var blocked computev1alpha.Instance
+		require.NoError(t, projectClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: instanceName}, &blocked))
+		quotaCond := apimeta.FindStatusCondition(blocked.Status.Conditions, computev1alpha.InstanceQuotaGranted)
+		require.NotNil(t, quotaCond)
+		assert.Equal(t, metav1.ConditionFalse, quotaCond.Status)
+
+		// Update the claim to be granted (simulating quota increase).
+		var existingClaim quotav1alpha1.ResourceClaim
+		require.NoError(t, mgmtClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: claimName}, &existingClaim))
+		existingClaim.Status.Conditions = []metav1.Condition{
+			{
+				Type:               quotav1alpha1.ResourceClaimGranted,
+				Status:             metav1.ConditionTrue,
+				Reason:             quotav1alpha1.ResourceClaimGrantedReason,
+				Message:            "quota now available",
+				LastTransitionTime: metav1.Now(),
+			},
+		}
+		require.NoError(t, mgmtClient.Status().Update(context.Background(), &existingClaim))
+
+		// Second reconcile should see granted claim and update status.
+		_, err = r.Reconcile(context.Background(), reconcileRequest(clusterName, namespace, instanceName))
+		require.NoError(t, err)
+
+		var recovered computev1alpha.Instance
+		require.NoError(t, projectClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: instanceName}, &recovered))
+		quotaCond = apimeta.FindStatusCondition(recovered.Status.Conditions, computev1alpha.InstanceQuotaGranted)
+		require.NotNil(t, quotaCond)
+		assert.Equal(t, metav1.ConditionTrue, quotaCond.Status)
+
+		// Third reconcile removes the gate (status is already true, no more status write needed).
+		_, err = r.Reconcile(context.Background(), reconcileRequest(clusterName, namespace, instanceName))
+		require.NoError(t, err)
+
+		require.NoError(t, projectClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: instanceName}, &recovered))
+		hasQuotaGate := false
+		for _, g := range recovered.Spec.Controller.SchedulingGates {
+			if g.Name == instancecontrol.QuotaSchedulingGate.String() {
+				hasQuotaGate = true
+			}
+		}
+		assert.False(t, hasQuotaGate, "QuotaSchedulingGate should have been removed after quota granted")
+	})
+
+	t.Run("deleted before grant: finalizer deletes claim and is removed", func(t *testing.T) {
+		s := newTestScheme(t)
+
+		now := metav1.Now()
+		instance := makeInstance(s,
+			computev1alpha.SchedulingGate{Name: instancecontrol.QuotaSchedulingGate.String()},
+		)
+		instance.DeletionTimestamp = &now
+
+		claim := makeClaim(s, metav1.ConditionFalse, quotav1alpha1.ResourceClaimPendingReason)
+
+		r, projectClient, mgmtClient := newReconciler(t, []client.Object{instance}, []client.Object{claim})
+
+		_, err := r.Reconcile(context.Background(), reconcileRequest(clusterName, namespace, instanceName))
+		require.NoError(t, err)
+
+		// Claim should have been deleted from the management cluster.
+		var deletedClaim quotav1alpha1.ResourceClaim
+		err = mgmtClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: claimName}, &deletedClaim)
+		assert.True(t, apierrors.IsNotFound(err), "ResourceClaim should have been deleted")
+
+		// Finalizer should have been removed. The fake client may have garbage
+		// collected the object once the last finalizer was cleared and
+		// DeletionTimestamp was set, so accept either a clean object or NotFound.
+		var updated computev1alpha.Instance
+		getErr := projectClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: instanceName}, &updated)
+		if getErr != nil {
+			assert.True(t, apierrors.IsNotFound(getErr), "unexpected error getting instance after finalizer removal")
+		} else {
+			assert.NotContains(t, updated.Finalizers, instanceQuotaFinalizer)
+		}
+	})
 }

--- a/internal/controller/instance_controller_test.go
+++ b/internal/controller/instance_controller_test.go
@@ -67,9 +67,9 @@ func newTestScheme(t *testing.T) *runtime.Scheme {
 }
 
 // reconcileRequest builds a multicluster reconcile.Request for a given instance.
-func reconcileRequest(namespace, name string) mcreconcile.Request {
+func reconcileRequest(name string) mcreconcile.Request {
 	return mcreconcile.Request{
-		Request:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+		Request:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: name}},
 		ClusterName: "test-project",
 	}
 }
@@ -620,7 +620,7 @@ func TestReconcileQuota(t *testing.T) {
 		r, projectClient, _ := newReconciler(t, []client.Object{instance, makeDeployment()}, []client.Object{claim})
 
 		// First reconcile: sets QuotaGranted=True in status, returns early.
-		_, err := r.Reconcile(context.Background(), reconcileRequest(namespace, instanceName))
+		_, err := r.Reconcile(context.Background(), reconcileRequest(instanceName))
 		require.NoError(t, err)
 
 		var updated computev1alpha.Instance
@@ -632,7 +632,7 @@ func TestReconcileQuota(t *testing.T) {
 		assert.Equal(t, computev1alpha.InstanceQuotaGrantedReasonQuotaAvailable, quotaCond.Reason)
 
 		// Second reconcile: status is already set, so removes the scheduling gate.
-		_, err = r.Reconcile(context.Background(), reconcileRequest(namespace, instanceName))
+		_, err = r.Reconcile(context.Background(), reconcileRequest(instanceName))
 		require.NoError(t, err)
 
 		require.NoError(t, projectClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: instanceName}, &updated))
@@ -656,7 +656,7 @@ func TestReconcileQuota(t *testing.T) {
 
 		r, projectClient, _ := newReconciler(t, []client.Object{instance, makeDeployment()}, []client.Object{claim})
 
-		_, err := r.Reconcile(context.Background(), reconcileRequest(namespace, instanceName))
+		_, err := r.Reconcile(context.Background(), reconcileRequest(instanceName))
 		require.NoError(t, err)
 
 		var updated computev1alpha.Instance
@@ -694,7 +694,7 @@ func TestReconcileQuota(t *testing.T) {
 		r, projectClient, mgmtClient := newReconciler(t, []client.Object{instance, makeDeployment()}, []client.Object{claim})
 
 		// First reconcile with denied claim.
-		_, err := r.Reconcile(context.Background(), reconcileRequest(namespace, instanceName))
+		_, err := r.Reconcile(context.Background(), reconcileRequest(instanceName))
 		require.NoError(t, err)
 
 		var blocked computev1alpha.Instance
@@ -718,7 +718,7 @@ func TestReconcileQuota(t *testing.T) {
 		require.NoError(t, mgmtClient.Status().Update(context.Background(), &existingClaim))
 
 		// Second reconcile should see granted claim and update status.
-		_, err = r.Reconcile(context.Background(), reconcileRequest(namespace, instanceName))
+		_, err = r.Reconcile(context.Background(), reconcileRequest(instanceName))
 		require.NoError(t, err)
 
 		var recovered computev1alpha.Instance
@@ -728,7 +728,7 @@ func TestReconcileQuota(t *testing.T) {
 		assert.Equal(t, metav1.ConditionTrue, quotaCond.Status)
 
 		// Third reconcile removes the gate (status is already true, no more status write needed).
-		_, err = r.Reconcile(context.Background(), reconcileRequest(namespace, instanceName))
+		_, err = r.Reconcile(context.Background(), reconcileRequest(instanceName))
 		require.NoError(t, err)
 
 		require.NoError(t, projectClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: instanceName}, &recovered))
@@ -754,7 +754,7 @@ func TestReconcileQuota(t *testing.T) {
 
 		r, projectClient, mgmtClient := newReconciler(t, []client.Object{instance}, []client.Object{claim})
 
-		_, err := r.Reconcile(context.Background(), reconcileRequest(namespace, instanceName))
+		_, err := r.Reconcile(context.Background(), reconcileRequest(instanceName))
 		require.NoError(t, err)
 
 		// Claim should have been deleted from the management cluster.

--- a/internal/controller/instancecontrol/scheduling_gates.go
+++ b/internal/controller/instancecontrol/scheduling_gates.go
@@ -4,6 +4,7 @@ type SchedulingGate string
 
 const (
 	NetworkSchedulingGate SchedulingGate = "Network"
+	QuotaSchedulingGate   SchedulingGate = "Quota"
 )
 
 func (s SchedulingGate) String() string {

--- a/internal/controller/instancecontrol/stateful/stateful_control.go
+++ b/internal/controller/instancecontrol/stateful/stateful_control.go
@@ -74,9 +74,8 @@ func (c *statefulControl) GetActions(
 			desiredInstances[i].Spec.Controller = &v1alpha.InstanceController{
 				TemplateHash: instanceTemplateHash,
 				SchedulingGates: []v1alpha.SchedulingGate{
-					{
-						Name: instancecontrol.NetworkSchedulingGate.String(),
-					},
+					{Name: instancecontrol.NetworkSchedulingGate.String()},
+					{Name: instancecontrol.QuotaSchedulingGate.String()},
 				},
 			}
 

--- a/internal/controller/workloaddeployment_controller.go
+++ b/internal/controller/workloaddeployment_controller.go
@@ -133,43 +133,14 @@ func (r *WorkloadDeploymentReconciler) Reconcile(ctx context.Context, req mcreco
 	// their gates removed.
 
 	replicas := len(instances.Items)
-	currentReplicas := 0
 	desiredReplicas := deployment.Spec.ScaleSettings.MinReplicas
 	if dt := deployment.DeletionTimestamp; !dt.IsZero() {
 		desiredReplicas = 0
 	}
 
-	readyReplicas := 0
-	quotaBlockedReplicas := 0
-	for _, instance := range instances.Items {
-		if apimeta.IsStatusConditionPresentAndEqual(instance.Status.Conditions, computev1alpha.InstanceQuotaGranted, metav1.ConditionFalse) {
-			quotaBlockedReplicas++
-		}
-
-		if networkReady && len(instance.Spec.Controller.SchedulingGates) > 0 {
-			newGates := slices.DeleteFunc(instance.Spec.Controller.SchedulingGates, func(gate computev1alpha.SchedulingGate) bool {
-				return gate.Name == instancecontrol.NetworkSchedulingGate.String()
-			})
-
-			if len(newGates) != len(instance.Spec.Controller.SchedulingGates) {
-				if _, err := controllerutil.CreateOrPatch(ctx, cl.GetClient(), &instance, func() error {
-					instance.Spec.Controller.SchedulingGates = newGates
-					return nil
-				}); err != nil {
-					return ctrl.Result{}, fmt.Errorf("failed updating instance: %w", err)
-				}
-			}
-		}
-
-		if apimeta.IsStatusConditionTrue(instance.Status.Conditions, computev1alpha.InstanceProgrammed) {
-			if instance.Status.Controller.ObservedTemplateHash == instancecontrol.ComputeHash(deployment.Spec.Template) {
-				currentReplicas++
-			}
-		}
-
-		if apimeta.IsStatusConditionTrue(instance.Status.Conditions, computev1alpha.InstanceReady) {
-			readyReplicas++
-		}
+	currentReplicas, readyReplicas, quotaBlockedReplicas, err := r.reconcileInstanceGates(ctx, cl.GetClient(), &deployment, instances.Items, networkReady)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	patchResult, err := controllerutil.CreateOrPatch(ctx, cl.GetClient(), &deployment, func() error {
@@ -227,6 +198,46 @@ func (r *WorkloadDeploymentReconciler) Reconcile(ctx context.Context, req mcreco
 	logger.Info("deployment status processed", "operation_result", patchResult)
 
 	return ctrl.Result{}, nil
+}
+
+func (r *WorkloadDeploymentReconciler) reconcileInstanceGates(
+	ctx context.Context,
+	c client.Client,
+	deployment *computev1alpha.WorkloadDeployment,
+	instances []computev1alpha.Instance,
+	networkReady bool,
+) (currentReplicas, readyReplicas, quotaBlockedReplicas int, err error) {
+	templateHash := instancecontrol.ComputeHash(deployment.Spec.Template)
+	for _, instance := range instances {
+		if apimeta.IsStatusConditionPresentAndEqual(instance.Status.Conditions, computev1alpha.InstanceQuotaGranted, metav1.ConditionFalse) {
+			quotaBlockedReplicas++
+		}
+
+		if networkReady && len(instance.Spec.Controller.SchedulingGates) > 0 {
+			newGates := slices.DeleteFunc(instance.Spec.Controller.SchedulingGates, func(gate computev1alpha.SchedulingGate) bool {
+				return gate.Name == instancecontrol.NetworkSchedulingGate.String()
+			})
+			if len(newGates) != len(instance.Spec.Controller.SchedulingGates) {
+				if _, patchErr := controllerutil.CreateOrPatch(ctx, c, &instance, func() error {
+					instance.Spec.Controller.SchedulingGates = newGates
+					return nil
+				}); patchErr != nil {
+					return 0, 0, 0, fmt.Errorf("failed updating instance: %w", patchErr)
+				}
+			}
+		}
+
+		if apimeta.IsStatusConditionTrue(instance.Status.Conditions, computev1alpha.InstanceProgrammed) {
+			if instance.Status.Controller.ObservedTemplateHash == templateHash {
+				currentReplicas++
+			}
+		}
+
+		if apimeta.IsStatusConditionTrue(instance.Status.Conditions, computev1alpha.InstanceReady) {
+			readyReplicas++
+		}
+	}
+	return currentReplicas, readyReplicas, quotaBlockedReplicas, nil
 }
 
 func (r *WorkloadDeploymentReconciler) reconcileNetworks(

--- a/internal/controller/workloaddeployment_controller.go
+++ b/internal/controller/workloaddeployment_controller.go
@@ -140,7 +140,12 @@ func (r *WorkloadDeploymentReconciler) Reconcile(ctx context.Context, req mcreco
 	}
 
 	readyReplicas := 0
+	quotaBlockedReplicas := 0
 	for _, instance := range instances.Items {
+		if apimeta.IsStatusConditionPresentAndEqual(instance.Status.Conditions, computev1alpha.InstanceQuotaGranted, metav1.ConditionFalse) {
+			quotaBlockedReplicas++
+		}
+
 		if networkReady && len(instance.Spec.Controller.SchedulingGates) > 0 {
 			newGates := slices.DeleteFunc(instance.Spec.Controller.SchedulingGates, func(gate computev1alpha.SchedulingGate) bool {
 				return gate.Name == instancecontrol.NetworkSchedulingGate.String()
@@ -172,6 +177,22 @@ func (r *WorkloadDeploymentReconciler) Reconcile(ctx context.Context, req mcreco
 		deployment.Status.CurrentReplicas = int32(currentReplicas)
 		deployment.Status.DesiredReplicas = desiredReplicas
 		deployment.Status.ReadyReplicas = int32(readyReplicas)
+
+		if quotaBlockedReplicas > 0 {
+			apimeta.SetStatusCondition(&deployment.Status.Conditions, metav1.Condition{
+				Type:    computev1alpha.WorkloadDeploymentReplicasReady,
+				Status:  metav1.ConditionFalse,
+				Reason:  computev1alpha.InstanceQuotaGrantedReasonQuotaExceeded,
+				Message: fmt.Sprintf("%d of %d desired replicas are pending quota", quotaBlockedReplicas, desiredReplicas),
+			})
+		} else {
+			apimeta.SetStatusCondition(&deployment.Status.Conditions, metav1.Condition{
+				Type:    computev1alpha.WorkloadDeploymentReplicasReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  "ReplicasAvailable",
+				Message: fmt.Sprintf("%d/%d replicas available", readyReplicas, desiredReplicas),
+			})
+		}
 
 		if readyReplicas > 0 {
 			apimeta.SetStatusCondition(&deployment.Status.Conditions, metav1.Condition{


### PR DESCRIPTION
## Summary

Without quota enforcement, there's no mechanism to prevent a single project from consuming unlimited compute resources or to give users visibility into how much of their allocation they're using. This adds Milo quota integration to the compute service so that resource consumption is tracked and enforced per project.

When a user creates an instance, it succeeds immediately — but provisioning is held until a quota claim is granted. If the project is within its limits, provisioning proceeds automatically. If quota is exceeded, the instance surfaces a clear `QuotaGranted=False` condition explaining what was exceeded rather than returning a creation error. When quota is later increased (tier upgrade or admin grant), pending instances resume provisioning on their own with no user action required.

Three dimensions are tracked per project: instance count, vCPUs (in millicores), and memory (in MiB).

## Changes

- **New**: `QuotaGranted` condition on `Instance` with `PendingEvaluation → QuotaAvailable / QuotaExceeded` lifecycle
- **New**: `QuotaSchedulingGate` that holds provisioning until the quota claim is granted
- **New**: `config/components/quota/` kustomize component with `ResourceRegistration` and `GrantCreationPolicy` resources
- **Modified**: Instance controller manages `ResourceClaim` lifecycle in the management cluster, watches for status changes, and removes the scheduling gate when quota is granted
- **Modified**: WorkloadDeployment controller surfaces a `ReplicasReady=False/QuotaExceeded` condition when any replicas are quota-blocked, and clears it automatically when quota recovers

## Test plan

- [ ] Quota granted flow: instance created → claim granted → `QuotaGranted=True`, scheduling gate removed, provisioning proceeds
- [ ] Quota exceeded flow: claim denied → `QuotaGranted=False`, `Programmed`/`Running`/`Ready` all blocked with `PendingQuota` reason
- [ ] Quota restored: denied instance self-recovers when grant is increased (no user action)
- [ ] Deleted before grant: finalizer cleans up the `ResourceClaim`, no provisioning attempted
- [ ] WorkloadDeployment `ReplicasReady` condition clears when quota-blocked replicas recover
- [ ] `go build ./...` and `go test ./...` pass

## Notes for reviewers

The `config/components/quota/` component is not yet wired into any overlay — it needs to be added to the target environment's kustomization once quota defaults are confirmed. Default quota amounts in `grant-creation-policy.yaml` (10 instances / 40 vCPUs / 80 GiB) are placeholders pending commercial input.

Closes #90