### PR TITLE
feat: Enforce quota for instances via Milo project control planes

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -158,7 +158,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	runnables, provider, err := initializeClusterDiscovery(serverConfig, deploymentCluster, scheme)
+	runnables, provider, projectRestConfig, edgeClusterName, err := initializeClusterDiscovery(
+		serverConfig, deploymentCluster, scheme,
+	)
 	if err != nil {
 		setupLog.Error(err, "unable to initialize cluster discovery")
 		os.Exit(1)
@@ -237,7 +239,7 @@ func main() {
 
 	if enableCellControllers {
 		instanceReconciler := &controller.InstanceReconciler{DownstreamClient: downstreamClient}
-		if err = instanceReconciler.SetupWithManager(mgr, deploymentCluster); err != nil {
+		if err = instanceReconciler.SetupWithManager(mgr, projectRestConfig, edgeClusterName); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Instance")
 			os.Exit(1)
 		}
@@ -345,7 +347,8 @@ func initializeClusterDiscovery(
 	serverConfig config.WorkloadOperator,
 	deploymentCluster cluster.Cluster,
 	scheme *runtime.Scheme,
-) (runnables []manager.Runnable, provider runnableProvider, err error) {
+) (runnables []manager.Runnable, provider runnableProvider,
+	projectRestConfig *rest.Config, edgeClusterName string, err error) {
 	runnables = append(runnables, deploymentCluster)
 	switch serverConfig.Discovery.Mode {
 	case multiclusterproviders.ProviderSingle:
@@ -355,14 +358,21 @@ func initializeClusterDiscovery(
 		}
 
 	case multiclusterproviders.ProviderMilo:
-		discoveryRestConfig, err := serverConfig.Discovery.DiscoveryRestConfig()
-		if err != nil {
-			return nil, nil, fmt.Errorf("unable to get discovery rest config: %w", err)
+		if serverConfig.Discovery.ClusterName == "" {
+			return nil, nil, nil, "", fmt.Errorf(
+				"discovery.clusterName must be set when mode is %q",
+				multiclusterproviders.ProviderMilo,
+			)
 		}
 
-		projectRestConfig, err := serverConfig.Discovery.ProjectRestConfig()
+		discoveryRestConfig, err := serverConfig.Discovery.DiscoveryRestConfig()
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to get project rest config: %w", err)
+			return nil, nil, nil, "", fmt.Errorf("unable to get discovery rest config: %w", err)
+		}
+
+		projectRestConfig, err = serverConfig.Discovery.ProjectRestConfig()
+		if err != nil {
+			return nil, nil, nil, "", fmt.Errorf("unable to get project rest config: %w", err)
 		}
 
 		discoveryManager, err := manager.New(discoveryRestConfig, manager.Options{
@@ -374,7 +384,7 @@ func initializeClusterDiscovery(
 			},
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to set up overall controller manager: %w", err)
+			return nil, nil, nil, "", fmt.Errorf("unable to set up overall controller manager: %w", err)
 		}
 
 		provider, err = milomulticluster.New(discoveryManager, milomulticluster.Options{
@@ -387,10 +397,11 @@ func initializeClusterDiscovery(
 			ProjectRestConfig:        projectRestConfig,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to create datum project provider: %w", err)
+			return nil, nil, nil, "", fmt.Errorf("unable to create datum project provider: %w", err)
 		}
 
 		runnables = append(runnables, discoveryManager)
+		edgeClusterName = serverConfig.Discovery.ClusterName
 
 	// case providers.ProviderKind:
 	// 	provider = mckind.New(mckind.Options{
@@ -402,13 +413,13 @@ func initializeClusterDiscovery(
 	// 	})
 
 	default:
-		return nil, nil, fmt.Errorf(
+		return nil, nil, nil, "", fmt.Errorf(
 			"unsupported cluster discovery mode %s",
 			serverConfig.Discovery.Mode,
 		)
 	}
 
-	return runnables, provider, nil
+	return runnables, provider, projectRestConfig, edgeClusterName, nil
 }
 
 func loadServerConfig(path string) (config.WorkloadOperator, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -229,6 +229,14 @@ type DiscoveryConfig struct {
 	// template when connecting to project control planes. When not provided,
 	// the operator will use the in-cluster config.
 	ProjectKubeconfigPath string `json:"projectKubeconfigPath"`
+
+	// ClusterName is the stable, unique name for this edge cluster. It is
+	// stamped onto ResourceClaim objects so that each edge controller can
+	// distinguish its own claims from those created by other edge controllers
+	// in the same project control planes.
+	//
+	// Required when Mode is "milo".
+	ClusterName string `json:"clusterName"`
 }
 
 func SetDefaults_DiscoveryConfig(obj *DiscoveryConfig) {

--- a/internal/controller/instance_controller.go
+++ b/internal/controller/instance_controller.go
@@ -12,7 +12,9 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -20,8 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/finalizer"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	ctrlsource "sigs.k8s.io/controller-runtime/pkg/source"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mccontext "sigs.k8s.io/multicluster-runtime/pkg/context"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
@@ -33,6 +35,7 @@ import (
 	"go.miloapis.com/milo/pkg/downstreamclient"
 
 	"go.datum.net/compute/internal/controller/instancecontrol"
+	"go.datum.net/compute/internal/quota"
 )
 
 const (
@@ -43,6 +46,12 @@ const (
 	// instanceControllerFinalizer is registered with the finalizer framework and
 	// triggers downstream write-back cleanup on deletion.
 	instanceControllerFinalizer = "compute.datumapis.com/instance-controller"
+
+	// instanceQuotaClaimSourceLabel is stamped on ResourceClaim objects with the
+	// name of the edge cluster that created them. The claim watch predicate uses
+	// this label to filter out claims written by other edge controllers targeting
+	// the same project control planes.
+	instanceQuotaClaimSourceLabel = "compute.datumapis.com/source-cluster"
 )
 
 // clusterGetter is the subset of mcmanager.Manager used by InstanceReconciler.
@@ -53,8 +62,10 @@ type clusterGetter interface {
 
 // InstanceReconciler reconciles an Instance object
 type InstanceReconciler struct {
-	mgr               clusterGetter
-	managementCluster cluster.Cluster
+	mgr                clusterGetter
+	scheme             *runtime.Scheme
+	quotaClientManager *quota.ProjectQuotaClientManager
+	edgeClusterName    string
 	// DownstreamClient is an optional client pointing at the downstream control plane.
 	// When non-nil, the reconciler writes a copy of each Instance back to the
 	// downstream control plane so that the InstanceProjector (running in the
@@ -103,7 +114,7 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req mcreconcile.Requ
 	defer logger.Info("reconcile complete")
 
 	if !instance.DeletionTimestamp.IsZero() {
-		return ctrl.Result{}, r.reconcileDeletion(ctx, cl.GetClient(), &instance)
+		return ctrl.Result{}, r.reconcileDeletion(ctx, cl.GetClient(), req.ClusterName, &instance)
 	}
 
 	if !controllerutil.ContainsFinalizer(&instance, instanceQuotaFinalizer) {
@@ -145,20 +156,27 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req mcreconcile.Requ
 
 // reconcileDeletion handles quota-claim cleanup when an Instance is being
 // deleted. It removes the quota finalizer once the ResourceClaim is gone.
-func (r *InstanceReconciler) reconcileDeletion(ctx context.Context, cl client.Client, instance *computev1alpha.Instance) error {
+func (r *InstanceReconciler) reconcileDeletion(ctx context.Context, cl client.Client, clusterName string, instance *computev1alpha.Instance) error {
 	if !controllerutil.ContainsFinalizer(instance, instanceQuotaFinalizer) {
 		return nil
 	}
 
-	claimName := fmt.Sprintf("%s--%s", instance.Namespace, instance.Name)
-	var claim quotav1alpha1.ResourceClaim
-	if err := r.managementCluster.GetClient().Get(ctx, client.ObjectKey{Namespace: instance.Namespace, Name: claimName}, &claim); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed getting resource claim for deletion: %w", err)
+	if r.quotaClientManager != nil {
+		projectClient, err := r.quotaClientManager.ClientForProject(ctx, clusterName, r.scheme)
+		if err != nil {
+			return fmt.Errorf("failed getting quota client for deletion: %w", err)
 		}
-	} else {
-		if err := r.managementCluster.GetClient().Delete(ctx, &claim); client.IgnoreNotFound(err) != nil {
-			return fmt.Errorf("failed deleting resource claim: %w", err)
+
+		claimName := fmt.Sprintf("%s--%s", instance.Namespace, instance.Name)
+		var claim quotav1alpha1.ResourceClaim
+		if err := projectClient.Get(ctx, client.ObjectKey{Namespace: instance.Namespace, Name: claimName}, &claim); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("failed getting resource claim for deletion: %w", err)
+			}
+		} else {
+			if err := projectClient.Delete(ctx, &claim); client.IgnoreNotFound(err) != nil {
+				return fmt.Errorf("failed deleting resource claim: %w", err)
+			}
 		}
 	}
 
@@ -343,7 +361,16 @@ func (r *InstanceReconciler) writeBackToDownstream(ctx context.Context, clusterN
 }
 
 func (r *InstanceReconciler) reconcileQuotaClaim(ctx context.Context, clusterName string, instance *computev1alpha.Instance) (*metav1.Condition, error) {
+	if r.quotaClientManager == nil {
+		return nil, nil
+	}
+
 	logger := log.FromContext(ctx)
+
+	projectClient, err := r.quotaClientManager.ClientForProject(ctx, clusterName, r.scheme)
+	if err != nil {
+		return nil, fmt.Errorf("failed getting quota client for project %q: %w", clusterName, err)
+	}
 
 	claimName := fmt.Sprintf("%s--%s", instance.Namespace, instance.Name)
 
@@ -374,6 +401,9 @@ func (r *InstanceReconciler) reconcileQuotaClaim(ctx context.Context, clusterNam
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      claimName,
 			Namespace: instance.Namespace,
+			Labels: map[string]string{
+				instanceQuotaClaimSourceLabel: r.edgeClusterName,
+			},
 		},
 		Spec: quotav1alpha1.ResourceClaimSpec{
 			ConsumerRef: quotav1alpha1.ConsumerRef{
@@ -392,11 +422,11 @@ func (r *InstanceReconciler) reconcileQuotaClaim(ctx context.Context, clusterNam
 	}
 
 	var existing quotav1alpha1.ResourceClaim
-	if err := r.managementCluster.GetClient().Get(ctx, client.ObjectKey{Namespace: desired.Namespace, Name: desired.Name}, &existing); err != nil {
+	if err := projectClient.Get(ctx, client.ObjectKey{Namespace: desired.Namespace, Name: desired.Name}, &existing); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed getting resource claim: %w", err)
 		}
-		if err := r.managementCluster.GetClient().Create(ctx, desired); err != nil {
+		if err := projectClient.Create(ctx, desired); err != nil {
 			return nil, fmt.Errorf("failed creating resource claim: %w", err)
 		}
 		return nil, nil
@@ -600,42 +630,46 @@ func (r *InstanceReconciler) checkForNetworkCreationFailure(ctx context.Context,
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *InstanceReconciler) SetupWithManager(mgr mcmanager.Manager, managementCluster cluster.Cluster) error {
+func (r *InstanceReconciler) SetupWithManager(mgr mcmanager.Manager, projectRestConfig *rest.Config, edgeClusterName string) error {
 	r.mgr = mgr
-	r.managementCluster = managementCluster
+	r.scheme = mgr.GetLocalManager().GetScheme()
+	r.edgeClusterName = edgeClusterName
+	if projectRestConfig != nil {
+		r.quotaClientManager = quota.New(projectRestConfig)
+	}
 
 	r.finalizers = finalizer.NewFinalizers()
 	if err := r.finalizers.Register(instanceControllerFinalizer, r); err != nil {
 		return fmt.Errorf("failed to register finalizer: %w", err)
 	}
 
-	// Watch ResourceClaim objects on the management cluster directly, bypassing
-	// the multicluster clusterInjectingQueue which would overwrite ClusterName.
-	// Using ctrlsource.TypedKind lets the handler produce mcreconcile.Request
-	// values with the correct ClusterName taken from claim.Spec.ConsumerRef.Name.
-	claimSource := ctrlsource.TypedKind(
-		managementCluster.GetCache(),
-		&quotav1alpha1.ResourceClaim{},
-		handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, claim *quotav1alpha1.ResourceClaim) []mcreconcile.Request {
-			if claim.Spec.ResourceRef.Kind != "Instance" || claim.Spec.ResourceRef.APIGroup != "compute.datumapis.com" {
-				return nil
-			}
-			return []mcreconcile.Request{
-				{
-					Request: reconcile.Request{
-						NamespacedName: types.NamespacedName{
-							Name:      claim.Spec.ResourceRef.Name,
-							Namespace: claim.Spec.ResourceRef.Namespace,
-						},
-					},
-					ClusterName: claim.Spec.ConsumerRef.Name,
-				},
-			}
-		}),
-	)
+	edgeClusterNameVal := r.edgeClusterName
 
 	return mcbuilder.ControllerManagedBy(mgr).
 		For(&computev1alpha.Instance{}, mcbuilder.WithEngageWithLocalCluster(false)).
-		WatchesRawSource(claimSource).
+		Watches(
+			&quotav1alpha1.ResourceClaim{},
+			func(_ string, _ cluster.Cluster) handler.TypedEventHandler[client.Object, mcreconcile.Request] {
+				return handler.TypedEnqueueRequestsFromMapFunc(
+					func(ctx context.Context, obj client.Object) []mcreconcile.Request {
+						claim := obj.(*quotav1alpha1.ResourceClaim)
+						return []mcreconcile.Request{
+							{
+								Request: reconcile.Request{
+									NamespacedName: types.NamespacedName{
+										Namespace: claim.Spec.ResourceRef.Namespace,
+										Name:      claim.Spec.ResourceRef.Name,
+									},
+								},
+								ClusterName: claim.Spec.ConsumerRef.Name,
+							},
+						}
+					},
+				)
+			},
+			mcbuilder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+				return obj.GetLabels()[instanceQuotaClaimSourceLabel] == edgeClusterNameVal
+			})),
+		).
 		Complete(r)
 }

--- a/internal/controller/instance_controller_test.go
+++ b/internal/controller/instance_controller_test.go
@@ -20,6 +20,7 @@ import (
 
 	computev1alpha "go.datum.net/compute/api/v1alpha"
 	"go.datum.net/compute/internal/controller/instancecontrol"
+	"go.datum.net/compute/internal/quota"
 	quotav1alpha1 "go.miloapis.com/milo/pkg/apis/quota/v1alpha1"
 )
 
@@ -541,7 +542,7 @@ func TestReconcileQuota(t *testing.T) {
 		}
 	}
 
-	newReconciler := func(t *testing.T, projectObjs []client.Object, mgmtObjs []client.Object) (*InstanceReconciler, client.Client, client.Client) {
+	newReconciler := func(t *testing.T, projectObjs []client.Object, quotaObjs []client.Object) (*InstanceReconciler, client.Client, client.Client) {
 		t.Helper()
 		s := newTestScheme(t)
 
@@ -551,9 +552,9 @@ func TestReconcileQuota(t *testing.T) {
 			WithStatusSubresource(&computev1alpha.Instance{}).
 			Build()
 
-		mgmtClient := fake.NewClientBuilder().
+		quotaClient := fake.NewClientBuilder().
 			WithScheme(s).
-			WithObjects(mgmtObjs...).
+			WithObjects(quotaObjs...).
 			WithStatusSubresource(&quotav1alpha1.ResourceClaim{}).
 			Build()
 
@@ -563,9 +564,14 @@ func TestReconcileQuota(t *testing.T) {
 			},
 		}
 
+		qm := quota.New(nil)
+		qm.StoreClient(clusterName, quotaClient)
+
 		r := &InstanceReconciler{
-			mgr:               mgr,
-			managementCluster: newFakeCluster(mgmtClient),
+			mgr:                mgr,
+			scheme:             s,
+			quotaClientManager: qm,
+			edgeClusterName:    "test-edge",
 		}
 
 		// Initialize the finalizer registry so that r.finalizers.Finalize is not
@@ -574,7 +580,7 @@ func TestReconcileQuota(t *testing.T) {
 		r.finalizers = finalizer.NewFinalizers()
 		require.NoError(t, r.finalizers.Register(instanceControllerFinalizer, r))
 
-		return r, projectClient, mgmtClient
+		return r, projectClient, quotaClient
 	}
 
 	t.Run("quota granted flow: claim granted removes gate and sets QuotaGranted=True", func(t *testing.T) {

--- a/internal/quota/client.go
+++ b/internal/quota/client.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package quota
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ProjectQuotaClientManager builds and caches controller-runtime clients that
+// target individual Milo project control planes. It is safe for concurrent use.
+type ProjectQuotaClientManager struct {
+	baseRestConfig *rest.Config
+	clients        sync.Map // key: projectID (string), value: client.Client
+}
+
+// New returns a ProjectQuotaClientManager that derives per-project REST configs
+// from baseRestConfig by rewriting the host path.
+func New(baseRestConfig *rest.Config) *ProjectQuotaClientManager {
+	return &ProjectQuotaClientManager{baseRestConfig: baseRestConfig}
+}
+
+// StoreClient pre-populates the cache with a pre-built client for projectID.
+// This is intended for use in unit tests where a real REST server is unavailable.
+func (m *ProjectQuotaClientManager) StoreClient(projectID string, cl client.Client) {
+	m.clients.Store(projectID, cl)
+}
+
+// ClientForProject returns a client.Client targeting the Milo project control
+// plane for projectID. The client is constructed once and cached for subsequent
+// calls. scheme must include all types the caller intends to operate on,
+// including quotav1alpha1.
+func (m *ProjectQuotaClientManager) ClientForProject(
+	ctx context.Context,
+	projectID string,
+	scheme *runtime.Scheme,
+) (client.Client, error) {
+	if v, ok := m.clients.Load(projectID); ok {
+		return v.(client.Client), nil
+	}
+
+	cfg := rest.CopyConfig(m.baseRestConfig)
+	apiHost, err := url.Parse(cfg.Host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse base host: %w", err)
+	}
+	apiHost.Path = fmt.Sprintf(
+		"/apis/resourcemanager.miloapis.com/v1alpha1/projects/%s/control-plane",
+		projectID,
+	)
+	cfg.Host = apiHost.String()
+
+	cl, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client for project %q: %w", projectID, err)
+	}
+
+	m.clients.Store(projectID, cl)
+	return cl, nil
+}


### PR DESCRIPTION
## Summary

Instances were silently bypassing quota enforcement because ResourceClaim objects were being written to the local deployment cluster instead of the Milo project control plane that owns the quota ledger. As a result, the Milo quota system never saw the claims, every Instance remained in `QuotaGranted=Unknown` indefinitely, and ResourceClaim objects accumulated in the wrong cluster without any evaluation.

This PR fixes quota enforcement end-to-end for instances: claims are now routed to the correct Milo project control plane for each project, the quota system evaluates them, and status changes (granted or denied) flow back to trigger instance reconciles.

Key behaviors:

- Instance quota claims are created in the Milo project control plane identified by the instance's project ID, so the quota system can evaluate and grant or deny them.
- Claims are stamped with the edge cluster name (`compute.datumapis.com/source-cluster`) so that multiple edge controllers sharing the same project control planes only react to their own claims.
- The `QuotaGranted` condition on instances now reflects real quota decisions from Milo rather than staying `Unknown`.
- A new `discovery.clusterName` field is required in the server config when running in Milo mode; startup fails fast with a clear error if it is absent.

## Test plan

- [ ] Deploy with a valid `discovery.clusterName` and confirm instances transition out of `QuotaGranted=Unknown`
- [ ] Confirm ResourceClaim objects appear in the correct Milo project control plane (not the local deployment cluster)
- [ ] Verify that deleting an Instance removes its ResourceClaim from the project control plane
- [ ] Deploy without `discovery.clusterName` set and confirm startup fails with a descriptive error
- [ ] Unit tests pass: `go test ./...`
