### PR TITLE
feat(config): wire feature gates through FEATURE_GATES env var in base deployment manifest

### DIFF
--- a/config/base/manager/manager.yaml
+++ b/config/base/manager/manager.yaml
@@ -36,6 +36,7 @@ spec:
           - --upstream-kubeconfig=$(UPSTREAM_KUBECONFIG)
           - --enable-management-controllers=$(ENABLE_MANAGEMENT_CONTROLLERS)
           - --enable-cell-controllers=$(ENABLE_CELL_CONTROLLERS)
+          - --feature-gates=$(FEATURE_GATES)
         env:
           - name: LEADER_ELECT
             value: "true"
@@ -49,6 +50,8 @@ spec:
             value: "false"
           - name: ENABLE_CELL_CONTROLLERS
             value: "false"
+          - name: FEATURE_GATES
+            value: ""
         image: ghcr.io/datum-cloud/compute:latest
         ports:
         - containerPort: 9443


### PR DESCRIPTION
## Summary

Feature gates are now set via the `FEATURE_GATES` environment variable in the base kustomize deployment manifest. Per-cell overlays can toggle any gate — such as `NetworkingIntegration=false` on cells without VPC — with a single strategic-merge env patch, rather than knowing the flag's raw argument syntax.

- `config/base/manager/manager.yaml`: appends `--feature-gates=$(FEATURE_GATES)` to the manager args and declares `FEATURE_GATES=""` in the container env.
- Empty default means the binary receives `--feature-gates=` and the existing `if featureGatesFlag != ""` guard (from PR #121) skips the `Set` call entirely — zero behaviour change on any existing cell.
- Overlays that need to disable networking (e.g. cells without NSO/VPC) patch only the env var: `FEATURE_GATES: "NetworkingIntegration=false"`.

This is consistent with how every other flag in the manifest is wired (e.g. `--upstream-kubeconfig=$(UPSTREAM_KUBECONFIG)`), so operators already know the pattern.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make test` — all tests pass (pre-existing lint issues in Go source are unrelated to this manifest-only change)
- [ ] Deploy to a staging cell with `FEATURE_GATES=""` (default): confirm `NetworkingIntegration` remains enabled and behaviour is unchanged.
- [ ] Deploy to a cell overlay with `FEATURE_GATES: "NetworkingIntegration=false"`: confirm networking gate is skipped and Instances proceed to the runtime without a NetworkBinding.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)