### PR TITLE
feat(service-catalog): require provider approval to enable compute

### DIFF
--- a/config/components/service-catalog/service.yaml
+++ b/config/components/service-catalog/service.yaml
@@ -9,5 +9,7 @@ spec:
   owner:
     producerProjectRef:
       name: datum-cloud
+  enablementPolicy:
+    mode: GatedByProvider
   phase: Published
   serviceName: compute.datumapis.com


### PR DESCRIPTION
## Summary

Enabling the Compute service now requires explicit provider approval. New consumers who enable the service will enter a `PendingApproval` state and remain there until a provider sets `spec.approval.decision: Approved` on their `ServiceEntitlement` or `ServiceConsumer` record. Previously, the service self-activated immediately on enablement.

The change is a single field added to the `compute` `Service` manifest in `config/components/service-catalog/service.yaml`:

```yaml
spec:
  enablementPolicy:
    mode: GatedByProvider
```

This sets `enablementPolicy.mode` from the implicit default (`SelfService`) to `GatedByProvider`, which is the valid enum value for provider-gated activation in the Milo service-catalog API (`services.miloapis.com/v1alpha1 EnablementPolicy.Mode`).

## Rollout impact

This policy change applies to **new service enablements only**. The `GatedByProvider` mode gates the transition from no-entitlement to active; it does not retroactively re-evaluate or revoke entitlements that are already in an `Active` state. Existing `ServiceEntitlement`/`ServiceConsumer` records — including the `datum-cloud` project — are expected to be unaffected by this manifest update.

Reviewers should confirm this interpretation against the Milo service-catalog controller behavior for their deployment, as the exact semantics (whether the controller re-evaluates policy on existing active entitlements) are determined by the Milo control plane, not by this manifest alone. If there is any doubt, coordinate with the Milo team before merging to staging/production overlays.

## Validation

`kubectl kustomize config/components/service-catalog` renders cleanly with the new field present in the `Service` output.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)