### PR TITLE
docs: Add RFC for mounting ConfigMaps and Secrets into instances

### DIFF
--- a/docs/compute/development/rfcs/configmap-secret-mounts.md
+++ b/docs/compute/development/rfcs/configmap-secret-mounts.md
@@ -4,767 +4,293 @@ status: proposed
 
 # Mounting ConfigMaps and Secrets into Compute Instances (Unikraft Provider)
 
-> Drafted: 2026-05-30 against compute branch `fix/federated-workload-health` and `datum-cloud/unikraft-provider` `main`. Revised 2026-05-31 after a second review round and a sequencing decision.
->
-> **This is the foundational referenced-data delivery design for compute, and it ships first** — before [Image Pull Credentials](./image-pull-credentials.md). It *introduces* the cross-plane machinery (the resolver, the scoped project-plane client, companion materialization, the referenced-data scheduling gate, and provider gate-honoring). Image-pull-credentials later becomes a **consumer** of this machinery: a pull secret is just one more kind of referenced data routed through the same resolver and gate. Nothing here depends on that RFC landing.
+> Drafted 2026-05-30, revised 2026-05-31. **This is the foundational referenced-data delivery design for compute, and it ships before [Image Pull Credentials](./image-pull-credentials.md)** — it introduces the resolver, the scoped project-plane client, companion delivery, and the scheduling gate; pull secrets become a later consumer of the same path.
 
 ## Table of Contents
 
 - [Summary](#summary)
 - [What this enables for users](#what-this-enables-for-users)
-- [Background: how config reaches an instance today](#background-how-config-reaches-an-instance-today)
-- [The core problem: two broken hops](#the-core-problem-two-broken-hops)
-- [Blocking dependencies](#blocking-dependencies)
-- [Design principles](#design-principles)
-- [Proposed design](#proposed-design)
-  - [Phase 1 — env injection from ConfigMap/Secret keys](#phase-1--env-injection-from-configmapsecret-keys)
-  - [Phase 2 — file mounts from ConfigMap/Secret volumes](#phase-2--file-mounts-from-configmapsecret-volumes)
-  - [Cross-plane delivery: the referenced-data resolver](#cross-plane-delivery-the-referenced-data-resolver)
-  - [Scheduling gate and provider consumption](#scheduling-gate-and-provider-consumption)
-  - [Rotation and rollout](#rotation-and-rollout)
-- [Alternatives considered](#alternatives-considered)
-- [Security considerations](#security-considerations)
-- [Failure modes and UX](#failure-modes-and-ux)
-- [File-level change list](#file-level-change-list)
-- [What review changed](#what-review-changed)
-- [Decided (previously open)](#decided-previously-open)
-- [Open questions for human decision](#open-questions-for-human-decision)
+- [End-to-end flow](#end-to-end-flow)
+- [The two hops](#the-two-hops)
+- [Design](#design)
+  - [Phase 1 — env injection (ships first)](#phase-1--env-injection-ships-first)
+  - [Phase 2 — file mounts (blocked on UKC)](#phase-2--file-mounts-blocked-on-ukc)
+  - [The referenced-data resolver](#the-referenced-data-resolver)
+  - [Scheduling gate and consumption](#scheduling-gate-and-consumption)
+  - [Rotation and restart](#rotation-and-restart)
+- [Security](#security)
+- [Alternatives](#alternatives)
+- [Failure modes](#failure-modes)
+- [File-level changes](#file-level-changes)
+- [Decisions](#decisions)
+- [Open questions](#open-questions)
 
 ---
 
 ## Summary
 
-A Datum compute `Workload` can already *describe* config and secret mounts. The
-Instance API models them:
+A compute `Workload` can already *describe* config/secret mounts — the Instance API
+has `Volumes[].ConfigMap/.Secret` (`instance_types.go:292,296`), `VolumeAttachments`
+with a `MountPath` (`:206`), and `Env` that parses `ValueFrom` (`:139`). But
+describing a mount is all that works. Two independent hops are broken:
 
-- `InstanceSpec.Volumes[].VolumeSource.ConfigMap` / `.Secret`
-  (`api/v1alpha/instance_types.go:292,296`) — populate a volume from a
-  ConfigMap/Secret.
-- `SandboxContainer.VolumeAttachments[]` with a `MountPath`
-  (`instance_types.go:206`) — attach a named volume into the container at a path.
-- `SandboxContainer.Env[]` is `corev1.EnvVar`, so `ValueFrom.ConfigMapKeyRef`
-  and `SecretKeyRef` already parse (`instance_types.go:139`).
+1. **Delivery (ours to fix).** The referenced object lives in the user's project
+   namespace; the Instance runs on an edge cell. Federation's `PropagationPolicy`
+   carries **only `WorkloadDeployment`** (`workloaddeployment_federator.go:284-293`),
+   so the data never reaches the cell.
+2. **Consumption (split).** Env injection maps onto UKC's inline `Env` and is
+   **buildable now**. File mounts need a UKC file-injection API that **does not
+   exist** — the same shape of blocker as the registry-auth gap.
 
-But describing a mount is *all* that works today. Like image pull credentials,
-this is **two independent broken hops**, and the more powerful of the two
-capabilities is gated on an external vendor:
-
-1. **The bytes have no cross-plane path.** The ConfigMap/Secret lives in the
-   user's project namespace; the Instance runs on an edge cell; nothing moves
-   the data between them. The federation `PropagationPolicy` selects **only
-   `WorkloadDeployment`** objects (`workloaddeployment_federator.go:284-293`), so
-   a referenced ConfigMap/Secret never lands on the cell. An Instance is created
-   on the cell with a dangling reference. There is no scheduling gate guarding
-   this, so the Instance is not even held back — it simply has no data.
-
-2. **The last hop for *file mounts* does not exist and cannot be built by us
-   alone.** kraftlet/UKC — which actually runs the instance — has **no
-   file-injection capability**. The UKC SDK `CreateInstanceRequest`
-   (`unikraft.com/cloud/sdk` `model_create_instance_request.go`) exposes `Env`
-   (inline `map[string]string`) and `Volumes` (references to *pre-created
-   persistent disks* by name/UUID with a mount point) — and **nothing for inline
-   files, projected volumes, ConfigMap/Secret data, or cloud-init provisioning**.
-   The provider doesn't even set Pod volumes today
-   (`unikraft-provider/internal/controller/instance_controller.go:180-239`), and
-   they would be ignored if it did. Mounting ConfigMap/Secret data **as files**
-   is impossible until UKC's API accepts injected file content — the same shape
-   of blocker as the registry-auth gap.
-
-The result is a clean split. **Env injection** (ConfigMap/Secret *keys* surfaced
-as environment variables) maps onto UKC's inline `Env` and is **buildable today**
-once the bytes reach the edge. **File mounts** (ConfigMap/Secret rendered as
-files at a path) are **blocked on UKC** and should be designed now but shipped
-when the upstream capability exists.
-
-This RFC keeps the **user contract unchanged** (create a ConfigMap/Secret,
-reference it from the Workload template), **introduces a single referenced-data
-resolver** as foundational platform infrastructure (image-pull-credentials will
-later route pull secrets through it rather than the reverse), and is explicit that
-secret bytes must **never be inlined into the Instance spec** (which is stored
-across planes and projected back to the user).
+This RFC keeps the user contract unchanged (create a ConfigMap/Secret, reference it
+by name), resolves it in the management plane, and delivers it to the edge as a
+companion object — secret bytes **never enter the Instance spec**. Env injection
+ships first; file mounts ship when Unikraft Cloud can accept file content.
 
 ## What this enables for users
 
-Today a user can only set literal environment variables on a container. They
-cannot point an instance at a ConfigMap or Secret they manage — so application
-config, API keys, database URLs, TLS material, and feature flags either get
-hard-coded into images or pasted as plaintext literals into the Workload.
+Today users can only set literal env vars, so config and credentials get baked into
+images or pasted as plaintext. After this:
 
-The happy path: a user creates a `ConfigMap` named `app-config` and a `Secret`
-named `app-secrets` in their project namespace, references them from the Workload
-template (`envFrom` or per-key `valueFrom`), and applies the Workload. With no
-further action, every instance the platform schedules — in every POP cell the
-workload is placed in — comes up with those keys present as environment
-variables. The user never learns that the instance runs on a cell thousands of
-miles from where they created the Secret.
+- A user creates a `ConfigMap` and `Secret` in their project and references them
+  from the Workload template; the platform delivers the data to every instance in
+  every POP cell, without the user knowing federation exists.
+- **Secrets stay secret** — values never land in the Workload/Instance spec or the
+  projected Instance; they travel only as Secret objects.
+- **Phase 1 (env):** keys surface as environment variables — the twelve-factor
+  case, no vendor dependency, so it ships first.
+- **Phase 2 (files):** a ConfigMap/Secret mounts as files at a path — for config
+  files and certs. Same API; lands when Unikraft Cloud supports file injection.
 
-With this work:
+## End-to-end flow
 
-- **Config and secrets are first-class, managed separately from the workload.**
-  A user creates a `ConfigMap` (app config) and a `Secret` (credentials) in their
-  project, then references them by name from the Workload template. The platform
-  delivers that data to every instance, in every POP cell the workload is placed
-  in, without the user knowing federation exists. This is the standard
-  twelve-factor pattern — configuration lives outside the image, not baked in or
-  pasted as plaintext literals.
-- **Secrets stay secret.** Values are never written into the Workload or Instance
-  spec, never projected back to the project plane in plaintext, and travel only
-  as Secret objects over the federation channel.
-- **Phase 1 (env):** keys from a ConfigMap/Secret appear as environment variables
-  inside the instance — the common case for twelve-factor apps. This is the
-  capability the Unikraft provider can deliver with no upstream vendor dependency
-  (it maps onto UKC's inline `Env`), so it's the first to ship.
-- **Phase 2 (files):** a ConfigMap/Secret is mounted as files at a path — needed
-  for config files and certificates. Lands when Unikraft Cloud supports file
-  injection; the user-facing API is identical, so no rework for users.
+Phase 1, the decided design (management-plane resolution → companion → Karmada →
+cell → provider). Management-plane controllers: `WorkloadReconciler`,
+`ReferencedDataController`, `WorkloadDeploymentFederator`. The edge cell and the
+compute provider run on the POP cell.
 
-## Background: how config reaches an instance today
+```mermaid
+sequenceDiagram
+    actor User
+    participant P as Project plane
+    participant WC as WorkloadReconciler
+    participant RDC as ReferencedDataController
+    participant F as Federator
+    participant K as Karmada hub
+    participant C as Edge cell
+    participant PR as Compute provider
+    participant U as kraftlet / UKC
 
-The flow `Workload → WorkloadDeployment → Instance` copies the instance template
-**verbatim** at each level:
-
-- `WorkloadReconciler` copies `workload.Spec.Template` into each
-  `WorkloadDeployment` (`workload_controller.go:439`).
-- The stateful instance-control strategy copies
-  `deployment.Spec.Template.Spec` straight into `Instance.Spec` with **no
-  reference resolution** (`instancecontrol/stateful/stateful_control.go:86`).
-
-On the cell side, the Unikraft provider's `InstanceReconciler` turns an Instance
-into a downstream Kubernetes Pod for kraftlet, mapping **only** container
-`Name`, `Image`, `Env` (literal `Value` only — `ValueFrom` is dropped), `Ports`,
-and a memory limit (`instance_controller.go:189-195`). It ignores
-`Volumes`, `VolumeAttachments`, `ImagePullSecrets`, `Command`, and `Args`.
-kraftlet then issues a UKC `CreateInstanceRequest`.
-
-So a referenced ConfigMap/Secret is dropped twice: it never leaves the project
-plane, and even if it arrived, the provider wouldn't read it.
-
-## The core problem: two broken hops
-
-```
-            project plane                     federation                 edge cell                    UKC
-  ┌─────────────────────────────┐      ┌──────────────────┐      ┌────────────────────┐      ┌─────────────────┐
-  │ Workload.template            │      │ Karmada hub      │      │ WorkloadDeployment │      │ kraftlet Pod    │
-  │  → WorkloadDeployment        │ ───▶ │ ns-{project-uid} │ ───▶ │  → Instance        │ ───▶ │  → UKC instance │
-  │ ConfigMap / Secret (project) │      │  WD only         │      │ (dangling ref)     │      │ Env ✓  files ✗  │
-  └─────────────────────────────┘      └──────────────────┘      └────────────────────┘      └─────────────────┘
-        HOP 1: bytes never propagated ───────────────────────────────────┘        HOP 2: no file-injection on UKC ─┘
+    User->>P: 1. Create ConfigMap + Secret
+    User->>P: 2. Create Workload referencing them
+    Note over P: Admission SubjectAccessReview —<br/>author may read referenced objects
+    WC->>P: 3. Create WorkloadDeployment per placement<br/>(template copied verbatim)
+    RDC->>P: 4. Read referenced ConfigMap/Secret<br/>(scoped project-plane client)
+    RDC->>K: 5. Materialize labeled companion in ns-{project-uid}
+    RDC->>P: 6. Annotate WD with expected-referenced-data set
+    F->>K: 7. Replicate WD + PropagationPolicy<br/>(city-code + referenced-data selectors)
+    K->>C: 8. Propagate WD + companions to matching cell
+    C->>C: 9. Create Instance with referenced-data gate<br/>(+ network, quota gates)
+    C->>C: 10. Companions present? clear gate,<br/>ReferencedDataReady=True
+    PR->>C: 11. Gate cleared — read companion (cell client)
+    Note over PR: Resolve Env valueFrom/envFrom to values<br/>(bytes only in the downstream Pod, never the Instance)
+    PR->>U: 12. Create kraftlet Pod with inline Env
+    U-->>User: 13. Instance running with config/secret applied
 ```
 
-- **Hop 1 (delivery) — ours to fix.** Get the referenced ConfigMap/Secret data
-  from the project namespace to `ns-{project-uid}` on each placed cell. The
-  PropagationPolicy must carry it, something must materialize it, and the
-  Instance must be held until it lands.
-- **Hop 2 (consumption) — split.** Env injection lands in UKC's inline `Env`
-  (buildable now). File mounts need a UKC file-injection API that does not exist.
+## The two hops
 
-## Blocking dependencies
+**Hop 1 — delivery (ours).** Get the referenced data from the project namespace to
+`ns-{project-uid}` on each placed cell, hold the Instance until it lands.
 
-- **B1 (file mounts only): Unikraft Cloud file injection.** UKC's
-  `CreateInstanceRequest` has no `files`/`user_data`/metadata field and its volume
-  API creates only empty, sized volumes with no content/init/snapshot/clone path —
-  so there is no way to get file bytes into an instance today. UKC must add a
-  file-injection capability (see [the upstream ask](#the-upstream-ask-what-would-unblock-b1)).
-  Tracked the same way as the registry-auth gap. Until then, `ConfigMap`/`Secret`
-  *volume* sources with `VolumeAttachments` are rejected at admission for the
-  Unikraft provider, or accepted-but-not-satisfied with a clear condition (see
-  [Open questions](#open-questions-for-human-decision)).
-- **B2: federation merge.** The resolver + PropagationPolicy extension live in the
-  management/federation path, so they require the federation work to be present.
-- **B3: a scoped project-plane client (this RFC builds it).** The resolver needs to
-  read project-namespace ConfigMaps and Secrets. The quota per-project client
-  **cannot** be reused — it targets a Milo control-plane path serving only quota
-  resources, not core ConfigMaps/Secrets ([memory: quota client is
-  quota-scoped]). This RFC introduces the dedicated full-Kubernetes project-plane
-  client; because ConfigMaps/Secrets ship first, **this is the RFC that owns
-  building it**, and image-pull-credentials reuses it later. This is a dependency
-  we build, not one we wait on.
+**Hop 2 — consumption.** Env injection lands in UKC's inline `Env` (buildable now).
+File mounts are blocked: UKC's `CreateInstanceRequest` exposes `Env`, `Args`, and
+`Volumes` (references to empty, pre-created disks) — **no `files`/`user_data`/
+metadata field, and no API to put bytes into a volume**. kraftlet's CRD spec *is*
+`CreateInstanceRequest`, so it never reads Pod volumes. This is **B1**: Unikraft
+Cloud must add file injection (recommended ask: a `files` array of
+`{path, content, mode}` on `CreateInstanceRequest`, mirroring cloud-init
+`write_files`). Until then, file mounts are rejected/held on the Unikraft provider.
 
-## Design principles
+## Design
 
-1. **Build the referenced-data delivery path here, once, as foundational
-   infrastructure.** Management-plane resolution → labeled companion object →
-   PropagationPolicy → scheduling gate → finalizer cleanup is general machinery,
-   not specific to config/secrets. Build **one resolver** that handles all
-   referenced data; ConfigMaps/Secrets are its first consumer, and pull secrets
-   (image-pull-credentials) become a later consumer of the same path. Designing it
-   general from the start is what lets image-pull-credentials be a thin addition
-   rather than a parallel system.
-2. **Secret bytes never enter an Instance or Workload spec.** Resolution that
-   inlines values would leak them into etcd on every plane and into the
-   user-visible projected Instance. References travel down; bytes travel only as
-   Secret objects.
-3. **Resolve in the management plane.** It already has legitimate project access.
-   Don't grant the shared edge identity broad project-Secret read.
-4. **Gate, don't race.** An Instance must not start until its referenced data is
-   confirmed present on the cell. Mirror the network/quota gate model.
-5. **One user contract across phases.** The API the user writes is identical for
-   env and file mounts; only the delivery/consumption backend differs by phase.
-6. **Degrade honestly.** On the Unikraft provider, file mounts are surfaced as
-   unsupported (clear condition) rather than silently ignored.
-7. **References are same-namespace and authorized.** A Workload may only
-   reference ConfigMaps/Secrets in its own project namespace (the API uses
-   name-only `LocalSecretReference`/`LocalObjectReference`, never a namespace),
-   and admission must verify the submitting principal can actually read the named
-   object — mirroring how `validateInstanceNetworkInterfaces` runs a
-   `SubjectAccessReview` for referenced Networks
-   (`instance_validation.go:118-141`). The resolver is a fixed system identity; it
-   must not become a confused deputy that reads objects the Workload author
-   couldn't.
+### Phase 1 — env injection (ships first)
 
-## Proposed design
+Surface ConfigMap/Secret keys as environment variables.
 
-### Phase 1 — env injection from ConfigMap/Secret keys
+- **API.** `ValueFrom` already parses. Add `EnvFrom []EnvFromSource` to
+  `SandboxContainer` for the bulk form; validate `ValueFrom`/`EnvFrom`
+  (`instance_validation.go`).
+- **Consumption (provider).** The provider holds an **upstream** (cell) client and
+  a **downstream** (kraftlet) client (`instance_controller.go:64-68,80`). Companions
+  land on the cell, so the provider reads them via the upstream client, resolves
+  `ValueFrom`/`EnvFrom` to values, and inlines them into the kraftlet Pod's `Env`
+  (`:189-195`, which today copies only `env.Value`) — not via Pod `ValueFrom` refs,
+  which kraftlet doesn't resolve.
 
-The buildable-today capability. Surface keys from a ConfigMap/Secret as
-environment variables inside the instance.
+### Phase 2 — file mounts (blocked on UKC)
 
-**API.** `ValueFrom` already parses on `Env`. Add the bulk form to match
-Kubernetes ergonomics and avoid per-key boilerplate:
+User writes `Volumes[].ConfigMap/.Secret` + `VolumeAttachments[].MountPath`; data
+renders as files (key→path, `items`, `defaultMode`, `optional`, read-only) — the
+standard Kubernetes projected-volume contract.
 
-- Add `EnvFrom []EnvFromSource` to `SandboxContainer` (`instance_types.go`),
-  mirroring `corev1.EnvFromSource` (`ConfigMapRef` / `SecretRef` + optional
-  `Prefix`). Regenerate deepcopy + CRDs (`make manifests generate`).
-- Add validation for `ValueFrom.ConfigMapKeyRef` / `SecretKeyRef` and `EnvFrom`
-  in `internal/validation/instance_validation.go` (key/name presence, `optional`
-  semantics).
+- **API gaps to close now (provider-agnostic).** Implement secret-volume validation
+  (`instance_validation.go:251`), ConfigMap/Secret `items` projection (forbidden at
+  `:341-343`), `defaultMode`/path-safety checks.
+- **Reference consumption.** `infra-provider-gcp` already mounts these — ConfigMap →
+  cloud-init `write_files`, Secret → Secret Manager + boot script
+  (`instance_controller.go:693-731,733-998`) — proving the compute *API* is a
+  portable contract. (GCP reads originals from its own upstream rather than using
+  companions, because its topology already sits next to them; `items` and env
+  `valueFrom` are still TODO there too, `:441`.)
+- **Consumption on UKC is blocked on B1.** No acceptable interim workaround:
+  base64-env-into-files needs wrapping the user's image and pushes secrets through
+  env; pre-populated volumes have no API; baking into the image is the status quo
+  this replaces.
 
-**Consumption (Unikraft provider).** The provider's `InstanceReconciler` already
-holds two clients: an **upstream** client for the cell cluster where the Instance
-(and the companion objects) live, and a **downstream** client for the kraftlet
-cluster where it creates Pods (`instance_controller.go:64-68,80`). The companion
-ConfigMap/Secret lands in `ns-{project-uid}` on the **cell** — i.e. behind the
-*upstream* client — so the provider reads it there, resolves `ValueFrom`/`EnvFrom`
-to concrete key/values, and inlines them into the kraftlet Pod's container `Env`
-(which kraftlet forwards to UKC's inline `Env`). Concretely, extend
-`buildPodSpecFromContainers` (`instance_controller.go:189-195`, which today copies
-only `env.Value`) to resolve references via the upstream client — **not** by
-emitting Pod `ValueFrom` refs (kraftlet does not resolve those, and the downstream
-kraftlet cluster has no copy of the companion objects).
+### The referenced-data resolver
 
-> Note: this is the one place secret bytes land in a Pod spec — the *downstream
-> kraftlet Pod*, which is infra-internal and never projected to the user. The
-> upstream Instance still carries only references. This boundary is deliberate
-> and called out in [Security](#security-considerations).
+A new management-plane `ReferencedDataController`:
 
-### Phase 2 — file mounts from ConfigMap/Secret volumes
+1. **Collect** every referenced ConfigMap/Secret from the WD template
+   (`Env.ValueFrom`, `EnvFrom`, `Volumes`; later `imagePullSecrets`).
+2. **Read** via the scoped project-plane client (B3 — this RFC builds it; not the
+   quota client, which serves only quota resources).
+3. **Materialize** one labeled companion per `(kind, source-name)` in
+   `ns-{project-uid}` (`compute.datumapis.com/referenced-data`).
+4. **Annotate** the WD with `compute.datumapis.com/expected-referenced-data` (the
+   gate contract — propagated to the cell, not reverse-engineered).
+5. **Federate.** The federator's PropagationPolicy *always* includes the
+   `referenced-data` label selector, so a companion materialized after the policy is
+   still picked up — closing the federator-vs-resolver ordering race.
 
-The user writes `InstanceSpec.Volumes[]` with a `ConfigMap`/`Secret` source and a
-`SandboxContainer.VolumeAttachments[]` with a `MountPath`. The data is rendered as
-files under that path — the case that env injection cannot serve: config files an
-app reads by path (`nginx.conf`, `application.yaml`), TLS certificate/key pairs,
-CA bundles, `.json`/`.toml` blobs, and anything binary or larger than is sane for
-an environment variable.
+**Fan-out:** one hub companion per `(kind, source-name)`; Karmada replicates it to N
+cells — single-write lifecycle. **Ref-counting:** the shared companion tracks
+referencing WDs; a WD finalizer deletes it only when the last reference drops (no
+cross-cluster owner refs — Karmada GC doesn't honor them). **Single-cluster mode:**
+resolver still runs; companion is a local copy, gate clears locally.
 
-This phase is **blocked on Unikraft Cloud (B1)**. The compute-side API and
-delivery can and should land now; the Unikraft *consumption* waits on an upstream
-capability that does not exist today. The two halves are decoupled below.
+### Scheduling gate and consumption
 
-#### The user contract and fidelity target
+- Add a `compute.datumapis.com/referenced-data` gate at instance creation
+  (`stateful_control.go:94-107`) when the template carries any reference.
+- **Clearing (new cell-side logic, beside the quota-gate clear at
+  `instance_controller.go:233`):** wait for exactly the `expected-referenced-data`
+  set, then clear and set `ReferencedDataReady`.
+- **Observability:** `ReferencedDataReady` with explicit Reasons (`Resolving`,
+  `AwaitingPropagation`, `SourceNotFound`/`SourceUnauthorized`/`SourceTooLarge`,
+  `NameMismatch`, `FileMountsUnsupported`, `Ready`) + events + metrics.
+- The **provider must honor gates** — today it creates Pods without checking
+  `Spec.Controller.SchedulingGates` (`instance_controller.go:58-105`). This RFC adds
+  gate-honoring.
 
-"Mount a ConfigMap/Secret as files" is the standard Kubernetes projected-volume
-contract, and the platform should match it so behavior is unsurprising:
+### Rotation and restart
 
-- **key → path projection.** Each ConfigMap/Secret key becomes a file. Default
-  layout is one file per key named after the key; `items` lets the user remap
-  specific keys to relative paths (e.g. key `server.crt` → `tls/server.crt`).
-- **`defaultMode` / per-item `mode`.** File permission bits (e.g. `0400` for a
-  private key).
-- **`optional`.** A missing source is skipped rather than holding the Instance.
-- **read-only mount** at the attachment's `MountPath`.
+Decided: **no auto-roll; explicit restart.** The resolver re-reads sources and
+re-materializes the companion on change (latest bytes staged at the edge), but
+running instances are not auto-rolled — a fleet-wide mass-roll on every edit is
+surprising, and UKC can't mutate a running instance's env anyway.
 
-#### API gaps to close (independent of B1 — do now)
+Content is deliberately **not** folded into the template hash. The restart reuses
+existing machinery: template metadata *is* in `ComputeHash` (`controller_utils.go:17-21`),
+and the stateful strategy already does an in-place, descending-ordinal,
+wait-for-Ready roll when the hash changes (`stateful_control.go:129-139,171-172`).
+So a `compute.datumapis.com/restartedAt` template annotation, threaded
+`Workload → WD → Instance`, triggers that roll — no new roll engine. (Opt-in
+auto-roll via a content hash is a possible future addition.)
 
-These make the *spec* complete and portable across providers regardless of UKC:
-
-- Implement **secret volume validation** — currently a bare TODO
-  (`instance_validation.go:251`).
-- Implement **ConfigMap `items` key→path projection** — currently **forbidden** by
-  validation (`instance_validation.go:341-343`); required for selective file
-  mapping and `defaultMode`. Do the same for Secret volumes.
-- Validate `defaultMode`/`mode` range and path safety (no `..`, no absolute
-  item paths) so a malicious or fat-fingered template can't escape the mount root.
-- Align the `Secret` volume struct naming with `ConfigMap`
-  (`instance_types.go:295` TODO) or document the divergence.
-
-#### Why this is blocked on UKC (B1), precisely
-
-UKC's instance-create API has **no path for file bytes**. From the SDK
-(`unikraft.com/cloud/sdk` `platform`):
-
-- `CreateInstanceRequest` exposes `Env map[string]string`, `Args []string`, and
-  `Volumes []CreateInstanceRequestVolume` — and **no `files`, `user_data`,
-  `cloud-init`, or metadata field of any kind**.
-- `CreateInstanceRequestVolume` references a volume by `Name`/`Uuid`, optionally
-  *creates* one by giving `SizeMb`, mounts it `At` a path, optionally `Readonly`.
-- The Volumes service (`CreateVolume`, `AttachVolume`, …) creates **empty, sized**
-  volumes only. There is **no content-upload, no init-data, no snapshot, and no
-  clone** endpoint — no way to get bytes into a volume through the API.
-
-kraftlet (the `unikraft-cloud/k8s-operator` virtual kubelet) compounds this: its
-`Instance` CRD spec *is* `platform.CreateInstanceRequest`, so it never reads Pod
-`Volumes`/`VolumeMounts`. Even if the provider populated Pod volumes, kraftlet
-would drop them. This is the same shape of blocker as the registry-auth gap
-([memory: unikraft no pull-secret support]).
-
-#### The upstream ask (what would unblock B1)
-
-We should request **one** of the following from Unikraft Cloud, ordered by
-preference for how cleanly it maps onto the ConfigMap/Secret-volume contract:
-
-1. **A `files` array (or `user_data`) on `CreateInstanceRequest`** — entries of
-   `{path, content (base64), mode}`. This is the cleanest fit: the provider
-   renders the projected volume into a file list and hands it over at create time,
-   no separate volume lifecycle to manage. (Mirrors how the GCP path uses
-   cloud-init `write_files`.)
-2. **Volume init-data on `CreateVolumeRequest`** — `init_data: [{path, content,
-   mode}]` so a volume is born populated, then attached read-only.
-3. **A volume content-upload endpoint** — `POST /volumes/{uuid}/content` — provider
-   creates → uploads → attaches. Most round-trips; weakest fit.
-
-Option 1 is the recommended ask. Track it alongside the registry-auth request as a
-named Unikraft Cloud dependency; this RFC's Phase 2 cannot ship without it.
-
-#### Reference consumption: the GCP provider already does this
-
-`infra-provider-gcp` is the proof that the *compute API* is a sufficient,
-portable contract — it consumes the same `Volumes`/`VolumeAttachments` model and
-renders files into the guest today
-(`infra-provider-gcp/internal/controller/instance_controller.go`):
-
-- **ConfigMap** → cloud-init `write_files`, materialized at
-  `/etc/configmaps/<name>/<key>` before boot, symlinked to the attachment
-  `MountPath` (`buildConfigMaps`, ~`:693-731`).
-- **Secret** → synced to GCP Secret Manager via Crossplane, fetched at boot by an
-  injected `populate_secrets.py` and written to `/etc/secrets/content/<name>/<key>`
-  (`reconcileSecrets`, ~`:733-998`).
-- It **honors scheduling gates** (`:119-122`) and reads the referenced objects
-  from its **upstream** cluster directly.
-
-Two honest caveats this revealed (correcting an earlier draft claim that "GCP is
-unblocked immediately"):
-
-- **GCP does not use the companion-object delivery this RFC proposes.** It fetches
-  the originals from *its* upstream and transforms them inline, because in its
-  topology the provider's upstream is the cluster that holds the originals. The
-  federated Unikraft path needs companions specifically because the *edge cell*
-  does not hold the originals — see the note in
-  [delivery](#cross-plane-delivery-the-referenced-data-resolver). So what is truly
-  "provider-agnostic" is the **Instance volume API**, not the delivery mechanism;
-  each provider sources the bytes however its topology and substrate allow.
-- **GCP's own gaps are real:** `items` projection is stubbed and env `ValueFrom`
-  is an explicit TODO (`:441`). So closing the validation/API gaps above benefits
-  GCP too, and Phase 1's env path is likewise per-provider work.
-
-#### Workarounds while B1 is unmet — and why none is the product answer
-
-- **Entrypoint/init shim decoding base64 env into files.** *Technically feasible*
-  (UKC has `Env`), but rejected as the platform behavior: it requires wrapping the
-  user's image (we don't own arbitrary user entrypoints), pushes secret bytes
-  through `Env` (the very exposure Phase 1 confines and Secret volumes exist to
-  avoid), and inherits env size limits. At most a documented user-side escape
-  hatch, never the platform's answer.
-- **Pre-populated / cloned volume.** *Not feasible* — no content, init, snapshot,
-  or clone API exists (above).
-- **Bake config into the image.** The status quo, and exactly what this feature
-  exists to eliminate. Not a path forward.
-
-Conclusion: there is no acceptable interim mechanism for file mounts on Unikraft;
-Phase 2 genuinely waits on B1. The compute-side API completeness and
-companion-delivery still land in Phase 1 so that (a) the spec is correct and
-validated, and (b) any provider whose substrate accepts files is ready to consume
-it the moment its consumption code is written.
-
-#### Interim UX on Unikraft (before B1)
-
-A user may still write a volume-backed ConfigMap/Secret mount in a Workload placed
-on Unikraft cells. The platform must not silently drop it. Either reject at
-admission with a message naming the unsupported capability, or admit and surface
-`ReferencedDataReady=False / Reason=FileMountsUnsupported` on the Instance — see
-[Open questions](#open-questions-for-human-decision). Whichever is chosen, the
-signal must be distinguishable from "companion not yet landed" so a user can tell
-"not supported here" from "still propagating."
-
-### Cross-plane delivery: the referenced-data resolver
-
-A new management-plane controller, the **`ReferencedDataController`**:
-
-1. **Collect references.** For each WorkloadDeployment, walk the template for all
-   referenced ConfigMaps/Secrets: every `Env.ValueFrom.*Ref`, every `EnvFrom.*Ref`,
-   and every `Volumes[].ConfigMap/.Secret` (and, once image-pull-credentials lands,
-   `imagePullSecrets`). Produce a deduplicated set of `(kind, name)` in the project
-   namespace.
-2. **Read with a scoped project-plane client** (B3) — the dedicated
-   full-Kubernetes client this RFC introduces, **not** the quota client.
-3. **Materialize labeled companions** into `ns-{project-uid}`: a derived
-   ConfigMap or Secret per referenced object, deterministic name, labeled
-   `compute.datumapis.com/referenced-data` (+ a kind/source label). Same
-   etcd-namespace as the WorkloadDeployment so it co-propagates.
-4. **Stamp the expected set on the WorkloadDeployment.** The resolver writes the
-   list of expected companion names as an annotation
-   (`compute.datumapis.com/expected-referenced-data`) on the WorkloadDeployment
-   *before* (or with) materialization. Karmada propagates the WD — annotation
-   included — to each cell, giving the cell-side gate-clearing reconciler an
-   explicit contract for which companions to wait for (see
-   [scheduling gate](#scheduling-gate-and-provider-consumption)). This is the
-   resolved form of the naming-determinism question: an explicit list, not
-   reverse-engineered names.
-5. **Extend the PropagationPolicy `resourceSelectors`**
-   (`workloaddeployment_federator.go:284-293`) to *always* include a selector for
-   the `referenced-data` label, independent of whether any companion exists yet.
-   The selector matches by label continuously, so a companion materialized **after**
-   the policy is in place is still picked up by Karmada on its next sync — this is
-   what closes the federator-vs-resolver ordering race (the two are independent
-   controllers; the label selector makes ordering irrelevant). Karmada lands
-   matching companions in `ns-{project-uid}` on each placed cell, beside the
-   Instance.
-
-**Fan-out (one hub object, N cell replicas).** There is exactly **one** companion
-per `(kind, source-name)` in `ns-{project-uid}` on the Karmada hub. Karmada's
-PropagationPolicy replicates that single object to each placed cell. N cities = N
-cell-side copies but **one** hub object — so creation, update, and deletion are all
-single-writes at the hub; Karmada garbage-collects the cell replicas. The resolver
-never enumerates cells.
-
-**Ref-counting and lifecycle.** A source ConfigMap/Secret may be referenced by
-several WorkloadDeployments in the same project. The single hub companion is
-shared; the resolver tracks the referencing WDs (a `referenced-data`-owner label
-set, or an explicit refs list on the companion) and deletes the companion only
-when the **last** referencing WD stops referencing it (template edited to drop the
-reference, or WD deleted). A **finalizer on the WorkloadDeployment** drives this:
-on WD delete/update the resolver decrements the ref set and removes the finalizer
-once it has reconciled the companion. Cleanup uses finalizers, **not** cross-cluster
-owner refs (Karmada/cross-plane GC does not honor them — [memory: WD UID
-cross-plane mismatch]). Deleting the hub companion lets Karmada GC the cell
-replicas.
-
-**Single-cluster mode.** In `single` mode there is no Karmada hop. The resolver
-**still runs** — it materializes the companion as a local copy in the project
-namespace's mapped location and stamps the same expected-set annotation; delivery
-is a local copy rather than a PropagationPolicy change, and the gate clears once
-the local companion exists. The path must be exercised in tests; absence of
-Karmada must not silently disable delivery.
-
-**Why companions, and not just "read the originals."** A provider can skip
-companions if its own upstream cluster already holds the referenced objects — this
-is what `infra-provider-gcp` does (it `Get`s the ConfigMap/Secret from its upstream
-and transforms it inline). That works because of *its* topology. In the federated
-Unikraft path the provider's local cluster is the **edge cell**, which never holds
-the user's project objects — so the bytes must be delivered there out-of-band.
-The companion mechanism is what bridges that gap; it is not redundant with a
-provider that happens to sit next to the originals.
-
-### Scheduling gate and provider consumption
-
-- Add a `compute.datumapis.com/referenced-data` **scheduling gate** to Instances
-  that reference any ConfigMap/Secret. The instance-control strategy already adds
-  network/quota gates at create time (`stateful_control.go:94-107`); add this gate
-  there when the template carries any reference, defined alongside the others in
-  `instancecontrol/scheduling_gates.go`.
-- **Who clears it.** There is no cell-side reconciler that validates companions
-  today — this must be built. The cell-side `WorkloadDeploymentReconciler`/
-  `InstanceReconciler` is the natural home (it already clears the quota gate at
-  `instance_controller.go:233`). It clears the referenced-data gate only when
-  **all** expected companions are present in the cell namespace, and surfaces a
-  `ReferencedDataReady` condition with per-object reasons.
-- **How it knows the expected set (decided).** The cell reconciler does **not**
-  reverse-engineer names. The resolver stamps the expected companion names on the
-  WorkloadDeployment as the `compute.datumapis.com/expected-referenced-data`
-  annotation (see [delivery](#cross-plane-delivery-the-referenced-data-resolver)),
-  Karmada propagates it to the cell, and the gate-clearing reconciler waits for
-  exactly that set to be present in the cell namespace. An explicit propagated list
-  — not a recomputed name — makes the cross-plane contract observable and survives
-  naming-scheme changes. (The earlier draft left this as an open question; it is
-  now decided.)
-- **Observability — a crisp condition, not a silent hang.** A held gate must be
-  diagnosable. Surface a `ReferencedDataReady` condition with explicit Reasons:
-  `Resolving` (resolver working), `AwaitingPropagation` (companions not yet on the
-  cell), `SourceNotFound` / `SourceUnauthorized` / `SourceTooLarge` (resolver can't
-  materialize — names the offending object), `NameMismatch` (expected-vs-present
-  diff, surfaced on the condition message), `FileMountsUnsupported` (Phase 2 on
-  UKC), and `Ready`. Emit Kubernetes Events on each transition and metrics
-  (`compute_referenced_data_companions_total`,
-  `compute_referenced_data_resolve_failures_total{reason}`, gate-wait duration), to
-  match the signal bar set by [quota-failure-modes](./quota-failure-modes.md).
-- The Unikraft provider must **honor scheduling gates** — today its `Reconcile`
-  proceeds straight to Pod creation without inspecting `Spec.Controller.SchedulingGates`
-  (`instance_controller.go:58-105`). It must requeue while any gate is present.
-  **This RFC introduces gate-honoring in the provider** (image-pull-credentials was
-  previously assumed to add it; since this ships first, that work lands here), so a
-  gated Instance is never handed to UKC with missing data.
-
-### Rotation and rollout
-
-**Decided:** running instances do **not** auto-roll on content change; the platform
-provides an explicit restart path. Rationale: an implicit mass-roll on every
-edit to a referenced object is surprising and risky at fleet scale, and UKC has no
-API to mutate a running instance's env anyway — the value only changes by replacing
-the instance. So rotation behaves like Kubernetes (mounting a changed ConfigMap
-doesn't roll a Deployment), but unlike bare Kubernetes we ship a first-class
-restart so operators aren't stuck.
-
-- **Rotation (source content changes).** The resolver re-reads source objects on a
-  periodic requeue and on Workload reconciles, tracking source `resourceVersion`;
-  on change it **re-materializes the companion** (single hub write; Karmada
-  re-propagates to cells). The latest bytes are therefore staged at the edge for
-  the next instance creation or roll. Running instances keep their current values
-  until replaced — surface the last-synced `resourceVersion` on the WorkloadDeployment
-  status so staleness is observable.
-- **Why content isn't in the template hash.** `instancecontrol.ComputeHash` hashes
-  the template spec, which holds only **references**, not resolved content
-  (`instancecontrol/controller_utils.go:17-21`). We deliberately do **not** fold
-  resolved content into it — that would be the auto-roll behavior we rejected.
-- **The restart path (reuses existing machinery, no new roll engine).** The
-  template hash **does** include template metadata, so changing an annotation on
-  the Workload template changes the Instance template hash, and the stateful
-  strategy already performs an in-place, descending-ordinal, wait-for-Ready rolling
-  update when the stored hash differs (`stateful/stateful_control.go:129-139`,
-  ordering at `:171-172`; `needsUpdate` at `stateful_control_util.go:11-13`). The
-  feature: a convention annotation (e.g. `compute.datumapis.com/restartedAt`) on the
-  Workload template that flows `Workload → WorkloadDeployment → Instance` and forces
-  exactly this roll. Setting/bumping it (by the user, or by an operator/automation
-  after a known rotation) rolls every instance, which re-reads the freshly
-  re-materialized companion. This is the entire restart mechanism — a documented
-  annotation plus the rolls compute already does. (An opt-in *auto*-roll — fold a
-  content hash in behind a per-Workload flag — remains a possible future addition,
-  not part of this RFC.)
-
-## Alternatives considered
-
-- **Inline resolved values into the Instance spec in the management plane.**
-  Simplest delivery (no companion objects, no gate). **Rejected:** leaks secret
-  bytes into etcd on every plane and into the user-visible projected Instance —
-  violates principle 2. Also breaks the immutability/diff model.
-- **Scoped per-project provider read at the edge (no companions).** The strongest
-  alternative, raised in review: give the provider a per-project scoped client (in
-  the spirit of the quota client) so it reads the referenced ConfigMaps/Secrets
-  directly from the project plane and resolves at the edge. *Steelman:* it deletes
-  most of this design — no companion materialization, no ref-counting, no
-  PropagationPolicy extension, no data scheduling gate, no cell-side gate-clearing
-  reconciler; rotation becomes "re-read," and it is far less to ship first. It is
-  also how `infra-provider-gcp` already works in its topology. **Rejected for the
-  delivery of secret bytes:** it requires the edge — a shared, lower-trust plane
-  that runs many tenants' instances — to hold a credential that can read project
-  ConfigMaps/Secrets. Even scoped per-project, that widens edge blast radius for the
-  most sensitive payload, and the resolution boundary (broad project-secret read
-  stays in the management plane) is the whole point of principle 3. The leanness
-  doesn't justify moving secret read to the edge. *(Considered for a config-only
-  hybrid — ConfigMaps via edge read, Secrets via companions — but rejected to avoid
-  maintaining two delivery mechanisms and two failure-mode sets for one feature.)*
-- **Reuse the quota per-project client to read project Secrets from the edge.**
-  **Rejected / not possible:** that client hits a Milo path serving only quota
-  resources, not core Secrets ([memory: quota client is quota-scoped]).
-- **Propagate the user's original objects via Karmada directly (no companion).**
-  **Rejected:** couples cell namespace contents to arbitrary project objects,
-  loses the labeling/scoping boundary, and complicates rotation/cleanup.
-- **A separate controller for pull-secrets, parallel to this one.** **Rejected:**
-  same collect→materialize→propagate→gate machinery. Since this ships first and
-  general, image-pull-credentials becomes a thin consumer (add `imagePullSecrets`
-  to the collected reference set, reuse the gate and scoped client) rather than a
-  parallel cross-plane system.
-- **Env-only, skip file mounts entirely.** Viable as Phase 1 scope, but the API
-  already models volumes and users will expect config files/TLS; designing
-  delivery once (provider-agnostic) keeps Phase 2 cheap.
-
-## Security considerations
+## Security
 
 - **Bytes never in user-visible specs.** Workload/Instance specs and the projected
-  Instance carry references only. Resolved values exist as Secret objects in
-  `ns-{project-uid}` (project plane, hub, cell) and — for env — in the downstream
-  kraftlet Pod, which is infra-internal and not projected to users.
-- **Companion Secrets are Secrets end-to-end**, never ConfigMaps, never inlined.
-  ConfigMap companions carry only non-secret config.
-- **Scoped read grant.** The resolver's project-plane client needs
-  `get`/`list`/`watch` on `configmaps` and `secrets` in project namespaces —
-  scope this via Milo IAM exactly as image-pull-credentials scopes pull-secret
-  read. No broader access than required.
-- **Cell namespace isolation.** Companions land in the per-project `ns-{uid}`
-  namespace, so one project cannot read another's data on a shared cell.
-- **Authorization at admission (mechanism confirmed).** Per principle 7, admission
-  runs a `SubjectAccessReview` confirming the Workload author can `get` each
-  referenced ConfigMap/Secret in their own namespace. The Network check already
-  does exactly this with the *submitter's* identity — it builds the SAR from
-  `opts.AdmissionRequest.UserInfo` (`Username`/`Groups`/`UID`/`Extra`)
-  (`instance_validation.go:113-131`), so the pattern transfers directly: same
-  `UserInfo`, verb `get`, resources `configmaps`/`secrets`, name from the reference,
-  namespace = the Workload's. This is the gate that prevents a user from naming an
-  object they couldn't read themselves; the resolver's system identity is never the
-  authority. The reconcile-time condition (`SourceUnauthorized`) is the backstop,
-  not the primary control.
-- **kraftlet Pod exposure boundary — the sharpest edge.** Inlining secret-derived
-  env into the downstream Pod is the cost of UKC's inline-only `Env`. The Pod is
-  created in the *downstream kraftlet cluster* via the downstream client
-  (`instance_controller.go:80,120-127`), in `ns-{project-uid}`, and is **not** the
-  object the `InstanceProjector` sends back to the project plane (it projects
-  Instances, not Pods). Two obligations make "infra-internal" real rather than
-  asserted: (1) the downstream kraftlet Pod must **never** be written back to the
-  Karmada hub or projected upstream — state this as an invariant and add a test
-  that fails if a Pod with inlined env appears on the hub; (2) anyone with
-  `pods/get` in the downstream `ns-{project-uid}` can read the values, so that
-  namespace's RBAC on the kraftlet cluster must be locked to platform components.
-  If UKC later accepts secret-aware env (resolving a reference rather than a
-  literal), drop the inlining entirely.
-- **Etcd at rest.** Companion Secrets exist in etcd on the project plane, the
-  Karmada hub, and each cell; the inlined kraftlet Pod adds the downstream cluster.
-  This is the same at-rest exposure image-pull-credentials accepts as a trade-off —
-  it presumes etcd encryption-at-rest on every plane. Call that assumption out
-  explicitly and confirm it per environment rather than leaving it implicit.
+  Instance carry references only. Values live as Secret objects in `ns-{project-uid}`
+  and — for env — in the downstream kraftlet Pod (infra-internal, not projected).
+- **Companion Secrets stay Secrets** end-to-end; ConfigMap companions carry only
+  non-secret config.
+- **Authorization (mechanism confirmed).** Admission runs a `SubjectAccessReview`
+  for the *submitter* (`AdmissionRequest.UserInfo`) on `get` of each referenced
+  object — a direct copy of the Network check (`instance_validation.go:113-131`).
+  Prevents naming an object the author couldn't read; the resolver's system identity
+  is never the authority.
+- **kraftlet Pod boundary.** Inlined env is the cost of UKC's inline-only `Env`. Two
+  obligations: the downstream Pod must never be written back to the hub (invariant +
+  test), and downstream `ns-{project-uid}` RBAC must be locked to platform
+  components. If UKC adds secret-aware env, drop the inlining.
+- **Etcd at rest.** Companions exist in etcd on project plane, hub, and each cell;
+  presumes encryption-at-rest per plane (same trade-off as image-pull-credentials).
 
-## Failure modes and UX
+## Alternatives
 
-- **Referenced object missing in project ns.** Resolver cannot materialize a
-  companion → Instance gate stays held → `ReferencedDataReady=False` with the
-  missing object named. `optional: true` sources are skipped, not held.
-- **Companion not yet landed on cell.** Gate held; condition surfaces "waiting for
-  data on cell". Normal transient state during placement.
-- **Source rotated but instances not rolled.** Stale-by-design (see
-  [rollout gap](#rotation-and-rollout)); surface last-synced `resourceVersion` on
-  the WorkloadDeployment status so it's observable.
-- **File-mount requested on Unikraft (B1 unmet).** Either rejected at admission
-  with a clear message, or accepted with `ReferencedDataReady=False /
-  Reason=FileMountsUnsupported` — decide in [open questions].
-- **Object too large / too many keys.** Bound companion size; reject oversized
-  references with a clear condition rather than failing propagation silently.
-- **Provider can't read companion on cell.** Instance not started;
-  surface a provider condition rather than booting with missing config.
-- **Unauthorized reference.** Author lacks read on a named object → rejected at
-  admission with a clear message, not deferred to a silent reconcile failure.
-- **Gate stuck on name mismatch.** If the cell reconciler's expected companion set
-  disagrees with what landed (naming-scheme drift), the gate never clears.
-  Mitigated by the explicit expected-name list (option (a) above); surface the
-  expected-vs-present diff on the condition so it's diagnosable, not a silent hang.
-- **Single-cluster mode.** Local copy path must be exercised in tests; absence of
-  Karmada must not silently disable delivery.
+- **Scoped per-project provider read at the edge (no companions).** Strongest
+  alternative — deletes most of this machinery (no companions, ref-counting, PP
+  extension, data gate) and is how GCP already works. **Rejected for secret bytes:**
+  it requires the shared, lower-trust edge to hold a credential that reads project
+  ConfigMaps/Secrets; the resolution boundary staying in the management plane is the
+  point. (A config-only hybrid was considered and rejected to avoid two delivery
+  mechanisms.)
+- **Inline resolved values into the Instance spec.** Rejected — leaks secret bytes
+  into etcd everywhere and into the projected Instance.
+- **Propagate the user's original objects directly.** Rejected — couples cell
+  contents to arbitrary project objects, loses the scoping boundary.
+- **A separate controller for pull-secrets.** Rejected — same machinery; pull
+  secrets become a thin consumer of this resolver.
 
-## File-level change list
+## Failure modes
+
+- **Source missing/unauthorized/too large** → gate held, `ReferencedDataReady=False`
+  naming the object; `optional` sources skipped.
+- **Companion not yet on cell** → gate held (`AwaitingPropagation`), normal transient
+  state.
+- **Source rotated, instances not rolled** → stale-by-design; surface last-synced
+  `resourceVersion` on WD status.
+- **File mount on Unikraft (B1 unmet)** → reject at admission or hold with
+  `FileMountsUnsupported` (open question), distinct from "still propagating".
+- **Single-cluster mode** → local-copy path must be tested; absence of Karmada must
+  not silently disable delivery.
+
+## File-level changes
 
 **compute (API + management):**
-- `api/v1alpha/instance_types.go` — add `EnvFrom` to `SandboxContainer`; align
-  Secret volume struct naming.
-- `internal/validation/instance_validation.go` — implement secret-volume
-  validation (`:251`), ConfigMap `items` projection (`:341-343`), `EnvFrom` and
-  `Env.ValueFrom` validation, and a `SubjectAccessReview` that the author can read
-  each referenced ConfigMap/Secret (pattern at `:118-141`).
-- `internal/quota/`-style new package — **scoped project-plane client** (B3): a
-  dedicated full-Kubernetes client for reading project-namespace ConfigMaps/Secrets.
-  This RFC owns it; image-pull-credentials reuses it later.
-- `internal/controller/` — **new `ReferencedDataController`**: collect refs, scoped
-  project-plane read, materialize one shared companion per `(kind, source-name)`,
-  stamp the `expected-referenced-data` annotation on the WD, ref-count referencing
-  WDs, finalizer-driven cleanup.
-- `internal/controller/workloaddeployment_federator.go:284-293` — extend the
-  PropagationPolicy `resourceSelectors` to *always* include the `referenced-data`
-  label selector (ordering-race-free).
-- `internal/controller/instancecontrol/scheduling_gates.go` +
-  `stateful_control.go:94-107` — define and add the `referenced-data` gate when the
-  template carries any reference.
-- cell-side reconciler (new gate-clearing logic, beside the quota-gate clear at
-  `instance_controller.go:233`) — wait for exactly the `expected-referenced-data`
-  set, clear the gate, set `ReferencedDataReady` with the Reason enum + events +
-  metrics.
-- restart path: thread a `compute.datumapis.com/restartedAt` template annotation
-  `Workload → WorkloadDeployment → Instance` (template metadata already feeds
-  `ComputeHash`, so the existing roll triggers — no new roll engine).
-- `make manifests generate`; tests including the single-cluster local-copy path.
+- `api/v1alpha/instance_types.go` — add `EnvFrom`; align Secret volume struct naming.
+- `internal/validation/instance_validation.go` — secret-volume validation (`:251`),
+  `items` projection (`:341-343`), `EnvFrom`/`ValueFrom` validation, and the
+  referenced-object `SubjectAccessReview` (pattern at `:113-131`).
+- new package — **scoped project-plane client** (B3); reused later by
+  image-pull-credentials.
+- `internal/controller/` — **new `ReferencedDataController`**: collect, read,
+  materialize one shared companion per `(kind, source-name)`, annotate the WD,
+  ref-count, finalizer cleanup.
+- `internal/controller/workloaddeployment_federator.go:284-293` — PropagationPolicy
+  always includes the `referenced-data` selector.
+- `instancecontrol/scheduling_gates.go` + `stateful_control.go:94-107` — define/add
+  the gate; cell-side clearing beside `instance_controller.go:233` with
+  `ReferencedDataReady` + reasons/events/metrics.
+- restart annotation `compute.datumapis.com/restartedAt` threaded
+  `Workload → WD → Instance`.
+- `make manifests generate`; tests including the single-cluster path.
 
 **unikraft-provider:**
-- `internal/controller/instance_controller.go:58-105` — **honor scheduling gates**
-  (requeue while any gate is present); this RFC owns introducing this.
-- `internal/controller/instance_controller.go:189-195` — honor `Env.ValueFrom` and
-  `EnvFrom` by resolving companion objects via the **upstream (cell)** client and
-  inlining values into the kraftlet Pod `Env`.
-- File mounts: reject/hold pending B1; map to UKC injection field when available.
+- `internal/controller/instance_controller.go:58-105` — honor scheduling gates.
+- `:189-195` — resolve `ValueFrom`/`EnvFrom` via the cell client; inline into the
+  kraftlet Pod `Env`.
+- File mounts: reject/hold pending B1.
 
-## What review changed
+## Decisions
 
-### Round 2 + sequencing decision (2026-05-31)
+- **Delivery:** management-plane companions (not scoped-edge-read).
+- **Rotation:** no auto-roll; explicit `restartedAt` restart.
+- **Gate contract:** explicit `expected-referenced-data` annotation, not recomputed
+  names.
+- **One resolver, not two:** pull secrets are a later consumer.
+- **Sequencing:** ships before image-pull-credentials; owns the scoped client and
+  provider gate-honoring.
 
-A second review (fact-check, implementation/ops, product/strategy) plus a product
-decision that **ConfigMaps/Secrets must ship before image-pull-credentials**
-reshaped the design:
+## Open questions
 
-- **Dependency inverted — this RFC is now foundational and self-contained.** It
-  *introduces* the resolver, the scoped project-plane client (B3), provider
-  gate-honoring, and the gate; image-pull-credentials becomes a later consumer.
-  Nothing here waits on that RFC.
-- **Delivery model decided: management-plane companions.** The scoped-edge-read
-  alternative (raised as the strongest hole — it would delete most of the
-  machinery) is now recorded in [Alternatives](#alternatives-considered),
-  steelmanned, and rejected for secret bytes because it widens edge blast radius;
-  the resolution boundary stays in the management plane.
-- **Rotation decided: no auto-roll + an explicit restart path.** Rewritten to reuse
-  the existing in-place ordered roll (template metadata already feeds `ComputeHash`)
-  via a `restartedAt` template annotation — no new roll engine. Auto-roll rejected
-  as a surprising fleet-wide mass-roll; UKC can't update a running instance's env
-  regardless.
-- **Round-2 gaps closed:** fan-out (one hub object, N Karmada replicas);
-  ref-counting + finalizer lifecycle for shared companions; the federator-vs-resolver
-  ordering race (label selector always present); the gate name contract (decided —
-  `expected-referenced-data` annotation propagated on the WD); observability
-  (`ReferencedDataReady` Reason enum + events + metrics); single-cluster local-copy
-  path made explicit; the SAR mechanism confirmed against the Network check
-  (`UserInfo` from the admission request).
-
-### Round 1
-
-The first review round (technical-correctness and security/product) reshaped the
-initial draft:
-
-- **The cell-side gate-clearing reconciler does not exist** and the original draft
-  hand-waved it. Now called out as net-new work, homed in the cell reconciler
-  beside the quota-gate clear, with an explicit **expected-companion-name contract**
-  to avoid a stuck-forever gate from naming drift.
-- **Provider client confusion.** The draft said "resolve on the cell" without
-  noting the provider's two clients. Pinned: companions are read via the
-  **upstream** (cell) client; the downstream kraftlet cluster has no copy.
-- **Downstream-Pod secret exposure** was dismissed as "infra-internal." Hardened
-  into two explicit obligations (never write the Pod back to the hub; lock down
-  downstream RBAC) plus a test, rather than an assertion.
-- **Authorization** was missing entirely. Added a same-namespace constraint and a
-  `SubjectAccessReview` at admission, mirroring the existing Network check, so a
-  user can't name an object they can't read (confused-deputy risk).
-- **Etcd-at-rest** assumption made explicit, consistent with image-pull-credentials.
-- **Product happy-path** narrative added up front; the draft led with the security
-  guarantee rather than what users gain.
-- **Unproven concerns down-weighted:** Karmada multi-kind `resourceSelectors` is a
-  standard feature (one policy, multiple selectors, same placement) and was
-  confirmed workable; the ordering race is genuinely mitigated by the gate; all
-  spot-checked file:line citations held.
-- **Phase 2 / GCP claim corrected.** A follow-up review of `infra-provider-gcp`
-  showed it mounts ConfigMaps/Secrets today (cloud-init `write_files`; Secret
-  Manager + boot script) but does **not** use companion delivery — it reads the
-  originals from its upstream and transforms inline. The original "GCP unblocked
-  immediately" line was misleading: what's provider-agnostic is the Instance
-  volume *API*, not the delivery mechanism. Phase 2 was also expanded with the
-  precise UKC capability gap (no `files`/`user_data`/volume-content API), the
-  recommended upstream ask, the projected-volume fidelity target, and a
-  workaround analysis concluding none is an acceptable platform answer.
-
-## Decided (previously open)
-
-- **Delivery model:** management-plane companions (not scoped-edge-read). See
-  [Alternatives](#alternatives-considered).
-- **Rotation:** no auto-roll; explicit restart via a `restartedAt` template
-  annotation. See [Rotation and rollout](#rotation-and-rollout).
-- **Gate name contract:** explicit `expected-referenced-data` annotation propagated
-  on the WorkloadDeployment, not recomputed names.
-- **One resolver, not two:** this RFC builds the general resolver; pull secrets are
-  a later consumer.
-- **Sequencing:** ships before image-pull-credentials; this RFC owns the scoped
-  client and provider gate-honoring.
-
-## Open questions for human decision
-
-1. **File-mount UX under B1:** reject at admission, or accept-and-hold with a
-   clear condition (`FileMountsUnsupported`)? Reject is honest; hold lets the same
-   Workload "just work" once UKC ships injection.
-2. **Scoped project-plane client (B3) granularity:** can Milo IAM scope the
-   resolver's read to specific types/labels per project namespace, or is it broad
-   `configmaps,secrets: [get,list,watch]`? This RFC owns building the client;
-   image-pull-credentials inherits whatever scoping is chosen here.
-3. **Companion size/key limits** and behavior on breach (per-object and aggregate
-   across a WorkloadDeployment fanned out to N cells).
-4. **Does `EnvFrom` belong in v1 of this work**, or is per-key `ValueFrom`
-   sufficient for the first release?
-5. **VM runtime (`VirtualMachineRuntime`)** consumption is out of scope for the
-   Unikraft provider (sandbox-only today) — confirm deferral.
+1. **File-mount UX under B1:** reject at admission, or accept-and-hold with
+   `FileMountsUnsupported`?
+2. **Scoped client granularity:** can Milo IAM scope the resolver's read to
+   types/labels per project namespace, or is it broad `configmaps,secrets:[get,list,watch]`?
+3. **Companion size/key limits** and behavior on breach.
+4. **`EnvFrom` in v1**, or per-key `ValueFrom` only for the first release?
+5. **VM runtime** consumption — out of scope for Unikraft (sandbox-only); confirm
+   deferral.

--- a/docs/compute/development/rfcs/configmap-secret-mounts.md
+++ b/docs/compute/development/rfcs/configmap-secret-mounts.md
@@ -1,0 +1,770 @@
+---
+status: proposed
+---
+
+# Mounting ConfigMaps and Secrets into Compute Instances (Unikraft Provider)
+
+> Drafted: 2026-05-30 against compute branch `fix/federated-workload-health` and `datum-cloud/unikraft-provider` `main`. Revised 2026-05-31 after a second review round and a sequencing decision.
+>
+> **This is the foundational referenced-data delivery design for compute, and it ships first** — before [Image Pull Credentials](./image-pull-credentials.md). It *introduces* the cross-plane machinery (the resolver, the scoped project-plane client, companion materialization, the referenced-data scheduling gate, and provider gate-honoring). Image-pull-credentials later becomes a **consumer** of this machinery: a pull secret is just one more kind of referenced data routed through the same resolver and gate. Nothing here depends on that RFC landing.
+
+## Table of Contents
+
+- [Summary](#summary)
+- [What this enables for users](#what-this-enables-for-users)
+- [Background: how config reaches an instance today](#background-how-config-reaches-an-instance-today)
+- [The core problem: two broken hops](#the-core-problem-two-broken-hops)
+- [Blocking dependencies](#blocking-dependencies)
+- [Design principles](#design-principles)
+- [Proposed design](#proposed-design)
+  - [Phase 1 — env injection from ConfigMap/Secret keys](#phase-1--env-injection-from-configmapsecret-keys)
+  - [Phase 2 — file mounts from ConfigMap/Secret volumes](#phase-2--file-mounts-from-configmapsecret-volumes)
+  - [Cross-plane delivery: the referenced-data resolver](#cross-plane-delivery-the-referenced-data-resolver)
+  - [Scheduling gate and provider consumption](#scheduling-gate-and-provider-consumption)
+  - [Rotation and rollout](#rotation-and-rollout)
+- [Alternatives considered](#alternatives-considered)
+- [Security considerations](#security-considerations)
+- [Failure modes and UX](#failure-modes-and-ux)
+- [File-level change list](#file-level-change-list)
+- [What review changed](#what-review-changed)
+- [Decided (previously open)](#decided-previously-open)
+- [Open questions for human decision](#open-questions-for-human-decision)
+
+---
+
+## Summary
+
+A Datum compute `Workload` can already *describe* config and secret mounts. The
+Instance API models them:
+
+- `InstanceSpec.Volumes[].VolumeSource.ConfigMap` / `.Secret`
+  (`api/v1alpha/instance_types.go:292,296`) — populate a volume from a
+  ConfigMap/Secret.
+- `SandboxContainer.VolumeAttachments[]` with a `MountPath`
+  (`instance_types.go:206`) — attach a named volume into the container at a path.
+- `SandboxContainer.Env[]` is `corev1.EnvVar`, so `ValueFrom.ConfigMapKeyRef`
+  and `SecretKeyRef` already parse (`instance_types.go:139`).
+
+But describing a mount is *all* that works today. Like image pull credentials,
+this is **two independent broken hops**, and the more powerful of the two
+capabilities is gated on an external vendor:
+
+1. **The bytes have no cross-plane path.** The ConfigMap/Secret lives in the
+   user's project namespace; the Instance runs on an edge cell; nothing moves
+   the data between them. The federation `PropagationPolicy` selects **only
+   `WorkloadDeployment`** objects (`workloaddeployment_federator.go:284-293`), so
+   a referenced ConfigMap/Secret never lands on the cell. An Instance is created
+   on the cell with a dangling reference. There is no scheduling gate guarding
+   this, so the Instance is not even held back — it simply has no data.
+
+2. **The last hop for *file mounts* does not exist and cannot be built by us
+   alone.** kraftlet/UKC — which actually runs the instance — has **no
+   file-injection capability**. The UKC SDK `CreateInstanceRequest`
+   (`unikraft.com/cloud/sdk` `model_create_instance_request.go`) exposes `Env`
+   (inline `map[string]string`) and `Volumes` (references to *pre-created
+   persistent disks* by name/UUID with a mount point) — and **nothing for inline
+   files, projected volumes, ConfigMap/Secret data, or cloud-init provisioning**.
+   The provider doesn't even set Pod volumes today
+   (`unikraft-provider/internal/controller/instance_controller.go:180-239`), and
+   they would be ignored if it did. Mounting ConfigMap/Secret data **as files**
+   is impossible until UKC's API accepts injected file content — the same shape
+   of blocker as the registry-auth gap.
+
+The result is a clean split. **Env injection** (ConfigMap/Secret *keys* surfaced
+as environment variables) maps onto UKC's inline `Env` and is **buildable today**
+once the bytes reach the edge. **File mounts** (ConfigMap/Secret rendered as
+files at a path) are **blocked on UKC** and should be designed now but shipped
+when the upstream capability exists.
+
+This RFC keeps the **user contract unchanged** (create a ConfigMap/Secret,
+reference it from the Workload template), **introduces a single referenced-data
+resolver** as foundational platform infrastructure (image-pull-credentials will
+later route pull secrets through it rather than the reverse), and is explicit that
+secret bytes must **never be inlined into the Instance spec** (which is stored
+across planes and projected back to the user).
+
+## What this enables for users
+
+Today a user can only set literal environment variables on a container. They
+cannot point an instance at a ConfigMap or Secret they manage — so application
+config, API keys, database URLs, TLS material, and feature flags either get
+hard-coded into images or pasted as plaintext literals into the Workload.
+
+The happy path: a user creates a `ConfigMap` named `app-config` and a `Secret`
+named `app-secrets` in their project namespace, references them from the Workload
+template (`envFrom` or per-key `valueFrom`), and applies the Workload. With no
+further action, every instance the platform schedules — in every POP cell the
+workload is placed in — comes up with those keys present as environment
+variables. The user never learns that the instance runs on a cell thousands of
+miles from where they created the Secret.
+
+With this work:
+
+- **Config and secrets are first-class, managed separately from the workload.**
+  A user creates a `ConfigMap` (app config) and a `Secret` (credentials) in their
+  project, then references them by name from the Workload template. The platform
+  delivers that data to every instance, in every POP cell the workload is placed
+  in, without the user knowing federation exists. This is the standard
+  twelve-factor pattern — configuration lives outside the image, not baked in or
+  pasted as plaintext literals.
+- **Secrets stay secret.** Values are never written into the Workload or Instance
+  spec, never projected back to the project plane in plaintext, and travel only
+  as Secret objects over the federation channel.
+- **Phase 1 (env):** keys from a ConfigMap/Secret appear as environment variables
+  inside the instance — the common case for twelve-factor apps. This is the
+  capability the Unikraft provider can deliver with no upstream vendor dependency
+  (it maps onto UKC's inline `Env`), so it's the first to ship.
+- **Phase 2 (files):** a ConfigMap/Secret is mounted as files at a path — needed
+  for config files and certificates. Lands when Unikraft Cloud supports file
+  injection; the user-facing API is identical, so no rework for users.
+
+## Background: how config reaches an instance today
+
+The flow `Workload → WorkloadDeployment → Instance` copies the instance template
+**verbatim** at each level:
+
+- `WorkloadReconciler` copies `workload.Spec.Template` into each
+  `WorkloadDeployment` (`workload_controller.go:439`).
+- The stateful instance-control strategy copies
+  `deployment.Spec.Template.Spec` straight into `Instance.Spec` with **no
+  reference resolution** (`instancecontrol/stateful/stateful_control.go:86`).
+
+On the cell side, the Unikraft provider's `InstanceReconciler` turns an Instance
+into a downstream Kubernetes Pod for kraftlet, mapping **only** container
+`Name`, `Image`, `Env` (literal `Value` only — `ValueFrom` is dropped), `Ports`,
+and a memory limit (`instance_controller.go:189-195`). It ignores
+`Volumes`, `VolumeAttachments`, `ImagePullSecrets`, `Command`, and `Args`.
+kraftlet then issues a UKC `CreateInstanceRequest`.
+
+So a referenced ConfigMap/Secret is dropped twice: it never leaves the project
+plane, and even if it arrived, the provider wouldn't read it.
+
+## The core problem: two broken hops
+
+```
+            project plane                     federation                 edge cell                    UKC
+  ┌─────────────────────────────┐      ┌──────────────────┐      ┌────────────────────┐      ┌─────────────────┐
+  │ Workload.template            │      │ Karmada hub      │      │ WorkloadDeployment │      │ kraftlet Pod    │
+  │  → WorkloadDeployment        │ ───▶ │ ns-{project-uid} │ ───▶ │  → Instance        │ ───▶ │  → UKC instance │
+  │ ConfigMap / Secret (project) │      │  WD only         │      │ (dangling ref)     │      │ Env ✓  files ✗  │
+  └─────────────────────────────┘      └──────────────────┘      └────────────────────┘      └─────────────────┘
+        HOP 1: bytes never propagated ───────────────────────────────────┘        HOP 2: no file-injection on UKC ─┘
+```
+
+- **Hop 1 (delivery) — ours to fix.** Get the referenced ConfigMap/Secret data
+  from the project namespace to `ns-{project-uid}` on each placed cell. The
+  PropagationPolicy must carry it, something must materialize it, and the
+  Instance must be held until it lands.
+- **Hop 2 (consumption) — split.** Env injection lands in UKC's inline `Env`
+  (buildable now). File mounts need a UKC file-injection API that does not exist.
+
+## Blocking dependencies
+
+- **B1 (file mounts only): Unikraft Cloud file injection.** UKC's
+  `CreateInstanceRequest` has no `files`/`user_data`/metadata field and its volume
+  API creates only empty, sized volumes with no content/init/snapshot/clone path —
+  so there is no way to get file bytes into an instance today. UKC must add a
+  file-injection capability (see [the upstream ask](#the-upstream-ask-what-would-unblock-b1)).
+  Tracked the same way as the registry-auth gap. Until then, `ConfigMap`/`Secret`
+  *volume* sources with `VolumeAttachments` are rejected at admission for the
+  Unikraft provider, or accepted-but-not-satisfied with a clear condition (see
+  [Open questions](#open-questions-for-human-decision)).
+- **B2: federation merge.** The resolver + PropagationPolicy extension live in the
+  management/federation path, so they require the federation work to be present.
+- **B3: a scoped project-plane client (this RFC builds it).** The resolver needs to
+  read project-namespace ConfigMaps and Secrets. The quota per-project client
+  **cannot** be reused — it targets a Milo control-plane path serving only quota
+  resources, not core ConfigMaps/Secrets ([memory: quota client is
+  quota-scoped]). This RFC introduces the dedicated full-Kubernetes project-plane
+  client; because ConfigMaps/Secrets ship first, **this is the RFC that owns
+  building it**, and image-pull-credentials reuses it later. This is a dependency
+  we build, not one we wait on.
+
+## Design principles
+
+1. **Build the referenced-data delivery path here, once, as foundational
+   infrastructure.** Management-plane resolution → labeled companion object →
+   PropagationPolicy → scheduling gate → finalizer cleanup is general machinery,
+   not specific to config/secrets. Build **one resolver** that handles all
+   referenced data; ConfigMaps/Secrets are its first consumer, and pull secrets
+   (image-pull-credentials) become a later consumer of the same path. Designing it
+   general from the start is what lets image-pull-credentials be a thin addition
+   rather than a parallel system.
+2. **Secret bytes never enter an Instance or Workload spec.** Resolution that
+   inlines values would leak them into etcd on every plane and into the
+   user-visible projected Instance. References travel down; bytes travel only as
+   Secret objects.
+3. **Resolve in the management plane.** It already has legitimate project access.
+   Don't grant the shared edge identity broad project-Secret read.
+4. **Gate, don't race.** An Instance must not start until its referenced data is
+   confirmed present on the cell. Mirror the network/quota gate model.
+5. **One user contract across phases.** The API the user writes is identical for
+   env and file mounts; only the delivery/consumption backend differs by phase.
+6. **Degrade honestly.** On the Unikraft provider, file mounts are surfaced as
+   unsupported (clear condition) rather than silently ignored.
+7. **References are same-namespace and authorized.** A Workload may only
+   reference ConfigMaps/Secrets in its own project namespace (the API uses
+   name-only `LocalSecretReference`/`LocalObjectReference`, never a namespace),
+   and admission must verify the submitting principal can actually read the named
+   object — mirroring how `validateInstanceNetworkInterfaces` runs a
+   `SubjectAccessReview` for referenced Networks
+   (`instance_validation.go:118-141`). The resolver is a fixed system identity; it
+   must not become a confused deputy that reads objects the Workload author
+   couldn't.
+
+## Proposed design
+
+### Phase 1 — env injection from ConfigMap/Secret keys
+
+The buildable-today capability. Surface keys from a ConfigMap/Secret as
+environment variables inside the instance.
+
+**API.** `ValueFrom` already parses on `Env`. Add the bulk form to match
+Kubernetes ergonomics and avoid per-key boilerplate:
+
+- Add `EnvFrom []EnvFromSource` to `SandboxContainer` (`instance_types.go`),
+  mirroring `corev1.EnvFromSource` (`ConfigMapRef` / `SecretRef` + optional
+  `Prefix`). Regenerate deepcopy + CRDs (`make manifests generate`).
+- Add validation for `ValueFrom.ConfigMapKeyRef` / `SecretKeyRef` and `EnvFrom`
+  in `internal/validation/instance_validation.go` (key/name presence, `optional`
+  semantics).
+
+**Consumption (Unikraft provider).** The provider's `InstanceReconciler` already
+holds two clients: an **upstream** client for the cell cluster where the Instance
+(and the companion objects) live, and a **downstream** client for the kraftlet
+cluster where it creates Pods (`instance_controller.go:64-68,80`). The companion
+ConfigMap/Secret lands in `ns-{project-uid}` on the **cell** — i.e. behind the
+*upstream* client — so the provider reads it there, resolves `ValueFrom`/`EnvFrom`
+to concrete key/values, and inlines them into the kraftlet Pod's container `Env`
+(which kraftlet forwards to UKC's inline `Env`). Concretely, extend
+`buildPodSpecFromContainers` (`instance_controller.go:189-195`, which today copies
+only `env.Value`) to resolve references via the upstream client — **not** by
+emitting Pod `ValueFrom` refs (kraftlet does not resolve those, and the downstream
+kraftlet cluster has no copy of the companion objects).
+
+> Note: this is the one place secret bytes land in a Pod spec — the *downstream
+> kraftlet Pod*, which is infra-internal and never projected to the user. The
+> upstream Instance still carries only references. This boundary is deliberate
+> and called out in [Security](#security-considerations).
+
+### Phase 2 — file mounts from ConfigMap/Secret volumes
+
+The user writes `InstanceSpec.Volumes[]` with a `ConfigMap`/`Secret` source and a
+`SandboxContainer.VolumeAttachments[]` with a `MountPath`. The data is rendered as
+files under that path — the case that env injection cannot serve: config files an
+app reads by path (`nginx.conf`, `application.yaml`), TLS certificate/key pairs,
+CA bundles, `.json`/`.toml` blobs, and anything binary or larger than is sane for
+an environment variable.
+
+This phase is **blocked on Unikraft Cloud (B1)**. The compute-side API and
+delivery can and should land now; the Unikraft *consumption* waits on an upstream
+capability that does not exist today. The two halves are decoupled below.
+
+#### The user contract and fidelity target
+
+"Mount a ConfigMap/Secret as files" is the standard Kubernetes projected-volume
+contract, and the platform should match it so behavior is unsurprising:
+
+- **key → path projection.** Each ConfigMap/Secret key becomes a file. Default
+  layout is one file per key named after the key; `items` lets the user remap
+  specific keys to relative paths (e.g. key `server.crt` → `tls/server.crt`).
+- **`defaultMode` / per-item `mode`.** File permission bits (e.g. `0400` for a
+  private key).
+- **`optional`.** A missing source is skipped rather than holding the Instance.
+- **read-only mount** at the attachment's `MountPath`.
+
+#### API gaps to close (independent of B1 — do now)
+
+These make the *spec* complete and portable across providers regardless of UKC:
+
+- Implement **secret volume validation** — currently a bare TODO
+  (`instance_validation.go:251`).
+- Implement **ConfigMap `items` key→path projection** — currently **forbidden** by
+  validation (`instance_validation.go:341-343`); required for selective file
+  mapping and `defaultMode`. Do the same for Secret volumes.
+- Validate `defaultMode`/`mode` range and path safety (no `..`, no absolute
+  item paths) so a malicious or fat-fingered template can't escape the mount root.
+- Align the `Secret` volume struct naming with `ConfigMap`
+  (`instance_types.go:295` TODO) or document the divergence.
+
+#### Why this is blocked on UKC (B1), precisely
+
+UKC's instance-create API has **no path for file bytes**. From the SDK
+(`unikraft.com/cloud/sdk` `platform`):
+
+- `CreateInstanceRequest` exposes `Env map[string]string`, `Args []string`, and
+  `Volumes []CreateInstanceRequestVolume` — and **no `files`, `user_data`,
+  `cloud-init`, or metadata field of any kind**.
+- `CreateInstanceRequestVolume` references a volume by `Name`/`Uuid`, optionally
+  *creates* one by giving `SizeMb`, mounts it `At` a path, optionally `Readonly`.
+- The Volumes service (`CreateVolume`, `AttachVolume`, …) creates **empty, sized**
+  volumes only. There is **no content-upload, no init-data, no snapshot, and no
+  clone** endpoint — no way to get bytes into a volume through the API.
+
+kraftlet (the `unikraft-cloud/k8s-operator` virtual kubelet) compounds this: its
+`Instance` CRD spec *is* `platform.CreateInstanceRequest`, so it never reads Pod
+`Volumes`/`VolumeMounts`. Even if the provider populated Pod volumes, kraftlet
+would drop them. This is the same shape of blocker as the registry-auth gap
+([memory: unikraft no pull-secret support]).
+
+#### The upstream ask (what would unblock B1)
+
+We should request **one** of the following from Unikraft Cloud, ordered by
+preference for how cleanly it maps onto the ConfigMap/Secret-volume contract:
+
+1. **A `files` array (or `user_data`) on `CreateInstanceRequest`** — entries of
+   `{path, content (base64), mode}`. This is the cleanest fit: the provider
+   renders the projected volume into a file list and hands it over at create time,
+   no separate volume lifecycle to manage. (Mirrors how the GCP path uses
+   cloud-init `write_files`.)
+2. **Volume init-data on `CreateVolumeRequest`** — `init_data: [{path, content,
+   mode}]` so a volume is born populated, then attached read-only.
+3. **A volume content-upload endpoint** — `POST /volumes/{uuid}/content` — provider
+   creates → uploads → attaches. Most round-trips; weakest fit.
+
+Option 1 is the recommended ask. Track it alongside the registry-auth request as a
+named Unikraft Cloud dependency; this RFC's Phase 2 cannot ship without it.
+
+#### Reference consumption: the GCP provider already does this
+
+`infra-provider-gcp` is the proof that the *compute API* is a sufficient,
+portable contract — it consumes the same `Volumes`/`VolumeAttachments` model and
+renders files into the guest today
+(`infra-provider-gcp/internal/controller/instance_controller.go`):
+
+- **ConfigMap** → cloud-init `write_files`, materialized at
+  `/etc/configmaps/<name>/<key>` before boot, symlinked to the attachment
+  `MountPath` (`buildConfigMaps`, ~`:693-731`).
+- **Secret** → synced to GCP Secret Manager via Crossplane, fetched at boot by an
+  injected `populate_secrets.py` and written to `/etc/secrets/content/<name>/<key>`
+  (`reconcileSecrets`, ~`:733-998`).
+- It **honors scheduling gates** (`:119-122`) and reads the referenced objects
+  from its **upstream** cluster directly.
+
+Two honest caveats this revealed (correcting an earlier draft claim that "GCP is
+unblocked immediately"):
+
+- **GCP does not use the companion-object delivery this RFC proposes.** It fetches
+  the originals from *its* upstream and transforms them inline, because in its
+  topology the provider's upstream is the cluster that holds the originals. The
+  federated Unikraft path needs companions specifically because the *edge cell*
+  does not hold the originals — see the note in
+  [delivery](#cross-plane-delivery-the-referenced-data-resolver). So what is truly
+  "provider-agnostic" is the **Instance volume API**, not the delivery mechanism;
+  each provider sources the bytes however its topology and substrate allow.
+- **GCP's own gaps are real:** `items` projection is stubbed and env `ValueFrom`
+  is an explicit TODO (`:441`). So closing the validation/API gaps above benefits
+  GCP too, and Phase 1's env path is likewise per-provider work.
+
+#### Workarounds while B1 is unmet — and why none is the product answer
+
+- **Entrypoint/init shim decoding base64 env into files.** *Technically feasible*
+  (UKC has `Env`), but rejected as the platform behavior: it requires wrapping the
+  user's image (we don't own arbitrary user entrypoints), pushes secret bytes
+  through `Env` (the very exposure Phase 1 confines and Secret volumes exist to
+  avoid), and inherits env size limits. At most a documented user-side escape
+  hatch, never the platform's answer.
+- **Pre-populated / cloned volume.** *Not feasible* — no content, init, snapshot,
+  or clone API exists (above).
+- **Bake config into the image.** The status quo, and exactly what this feature
+  exists to eliminate. Not a path forward.
+
+Conclusion: there is no acceptable interim mechanism for file mounts on Unikraft;
+Phase 2 genuinely waits on B1. The compute-side API completeness and
+companion-delivery still land in Phase 1 so that (a) the spec is correct and
+validated, and (b) any provider whose substrate accepts files is ready to consume
+it the moment its consumption code is written.
+
+#### Interim UX on Unikraft (before B1)
+
+A user may still write a volume-backed ConfigMap/Secret mount in a Workload placed
+on Unikraft cells. The platform must not silently drop it. Either reject at
+admission with a message naming the unsupported capability, or admit and surface
+`ReferencedDataReady=False / Reason=FileMountsUnsupported` on the Instance — see
+[Open questions](#open-questions-for-human-decision). Whichever is chosen, the
+signal must be distinguishable from "companion not yet landed" so a user can tell
+"not supported here" from "still propagating."
+
+### Cross-plane delivery: the referenced-data resolver
+
+A new management-plane controller, the **`ReferencedDataController`**:
+
+1. **Collect references.** For each WorkloadDeployment, walk the template for all
+   referenced ConfigMaps/Secrets: every `Env.ValueFrom.*Ref`, every `EnvFrom.*Ref`,
+   and every `Volumes[].ConfigMap/.Secret` (and, once image-pull-credentials lands,
+   `imagePullSecrets`). Produce a deduplicated set of `(kind, name)` in the project
+   namespace.
+2. **Read with a scoped project-plane client** (B3) — the dedicated
+   full-Kubernetes client this RFC introduces, **not** the quota client.
+3. **Materialize labeled companions** into `ns-{project-uid}`: a derived
+   ConfigMap or Secret per referenced object, deterministic name, labeled
+   `compute.datumapis.com/referenced-data` (+ a kind/source label). Same
+   etcd-namespace as the WorkloadDeployment so it co-propagates.
+4. **Stamp the expected set on the WorkloadDeployment.** The resolver writes the
+   list of expected companion names as an annotation
+   (`compute.datumapis.com/expected-referenced-data`) on the WorkloadDeployment
+   *before* (or with) materialization. Karmada propagates the WD — annotation
+   included — to each cell, giving the cell-side gate-clearing reconciler an
+   explicit contract for which companions to wait for (see
+   [scheduling gate](#scheduling-gate-and-provider-consumption)). This is the
+   resolved form of the naming-determinism question: an explicit list, not
+   reverse-engineered names.
+5. **Extend the PropagationPolicy `resourceSelectors`**
+   (`workloaddeployment_federator.go:284-293`) to *always* include a selector for
+   the `referenced-data` label, independent of whether any companion exists yet.
+   The selector matches by label continuously, so a companion materialized **after**
+   the policy is in place is still picked up by Karmada on its next sync — this is
+   what closes the federator-vs-resolver ordering race (the two are independent
+   controllers; the label selector makes ordering irrelevant). Karmada lands
+   matching companions in `ns-{project-uid}` on each placed cell, beside the
+   Instance.
+
+**Fan-out (one hub object, N cell replicas).** There is exactly **one** companion
+per `(kind, source-name)` in `ns-{project-uid}` on the Karmada hub. Karmada's
+PropagationPolicy replicates that single object to each placed cell. N cities = N
+cell-side copies but **one** hub object — so creation, update, and deletion are all
+single-writes at the hub; Karmada garbage-collects the cell replicas. The resolver
+never enumerates cells.
+
+**Ref-counting and lifecycle.** A source ConfigMap/Secret may be referenced by
+several WorkloadDeployments in the same project. The single hub companion is
+shared; the resolver tracks the referencing WDs (a `referenced-data`-owner label
+set, or an explicit refs list on the companion) and deletes the companion only
+when the **last** referencing WD stops referencing it (template edited to drop the
+reference, or WD deleted). A **finalizer on the WorkloadDeployment** drives this:
+on WD delete/update the resolver decrements the ref set and removes the finalizer
+once it has reconciled the companion. Cleanup uses finalizers, **not** cross-cluster
+owner refs (Karmada/cross-plane GC does not honor them — [memory: WD UID
+cross-plane mismatch]). Deleting the hub companion lets Karmada GC the cell
+replicas.
+
+**Single-cluster mode.** In `single` mode there is no Karmada hop. The resolver
+**still runs** — it materializes the companion as a local copy in the project
+namespace's mapped location and stamps the same expected-set annotation; delivery
+is a local copy rather than a PropagationPolicy change, and the gate clears once
+the local companion exists. The path must be exercised in tests; absence of
+Karmada must not silently disable delivery.
+
+**Why companions, and not just "read the originals."** A provider can skip
+companions if its own upstream cluster already holds the referenced objects — this
+is what `infra-provider-gcp` does (it `Get`s the ConfigMap/Secret from its upstream
+and transforms it inline). That works because of *its* topology. In the federated
+Unikraft path the provider's local cluster is the **edge cell**, which never holds
+the user's project objects — so the bytes must be delivered there out-of-band.
+The companion mechanism is what bridges that gap; it is not redundant with a
+provider that happens to sit next to the originals.
+
+### Scheduling gate and provider consumption
+
+- Add a `compute.datumapis.com/referenced-data` **scheduling gate** to Instances
+  that reference any ConfigMap/Secret. The instance-control strategy already adds
+  network/quota gates at create time (`stateful_control.go:94-107`); add this gate
+  there when the template carries any reference, defined alongside the others in
+  `instancecontrol/scheduling_gates.go`.
+- **Who clears it.** There is no cell-side reconciler that validates companions
+  today — this must be built. The cell-side `WorkloadDeploymentReconciler`/
+  `InstanceReconciler` is the natural home (it already clears the quota gate at
+  `instance_controller.go:233`). It clears the referenced-data gate only when
+  **all** expected companions are present in the cell namespace, and surfaces a
+  `ReferencedDataReady` condition with per-object reasons.
+- **How it knows the expected set (decided).** The cell reconciler does **not**
+  reverse-engineer names. The resolver stamps the expected companion names on the
+  WorkloadDeployment as the `compute.datumapis.com/expected-referenced-data`
+  annotation (see [delivery](#cross-plane-delivery-the-referenced-data-resolver)),
+  Karmada propagates it to the cell, and the gate-clearing reconciler waits for
+  exactly that set to be present in the cell namespace. An explicit propagated list
+  — not a recomputed name — makes the cross-plane contract observable and survives
+  naming-scheme changes. (The earlier draft left this as an open question; it is
+  now decided.)
+- **Observability — a crisp condition, not a silent hang.** A held gate must be
+  diagnosable. Surface a `ReferencedDataReady` condition with explicit Reasons:
+  `Resolving` (resolver working), `AwaitingPropagation` (companions not yet on the
+  cell), `SourceNotFound` / `SourceUnauthorized` / `SourceTooLarge` (resolver can't
+  materialize — names the offending object), `NameMismatch` (expected-vs-present
+  diff, surfaced on the condition message), `FileMountsUnsupported` (Phase 2 on
+  UKC), and `Ready`. Emit Kubernetes Events on each transition and metrics
+  (`compute_referenced_data_companions_total`,
+  `compute_referenced_data_resolve_failures_total{reason}`, gate-wait duration), to
+  match the signal bar set by [quota-failure-modes](./quota-failure-modes.md).
+- The Unikraft provider must **honor scheduling gates** — today its `Reconcile`
+  proceeds straight to Pod creation without inspecting `Spec.Controller.SchedulingGates`
+  (`instance_controller.go:58-105`). It must requeue while any gate is present.
+  **This RFC introduces gate-honoring in the provider** (image-pull-credentials was
+  previously assumed to add it; since this ships first, that work lands here), so a
+  gated Instance is never handed to UKC with missing data.
+
+### Rotation and rollout
+
+**Decided:** running instances do **not** auto-roll on content change; the platform
+provides an explicit restart path. Rationale: an implicit mass-roll on every
+edit to a referenced object is surprising and risky at fleet scale, and UKC has no
+API to mutate a running instance's env anyway — the value only changes by replacing
+the instance. So rotation behaves like Kubernetes (mounting a changed ConfigMap
+doesn't roll a Deployment), but unlike bare Kubernetes we ship a first-class
+restart so operators aren't stuck.
+
+- **Rotation (source content changes).** The resolver re-reads source objects on a
+  periodic requeue and on Workload reconciles, tracking source `resourceVersion`;
+  on change it **re-materializes the companion** (single hub write; Karmada
+  re-propagates to cells). The latest bytes are therefore staged at the edge for
+  the next instance creation or roll. Running instances keep their current values
+  until replaced — surface the last-synced `resourceVersion` on the WorkloadDeployment
+  status so staleness is observable.
+- **Why content isn't in the template hash.** `instancecontrol.ComputeHash` hashes
+  the template spec, which holds only **references**, not resolved content
+  (`instancecontrol/controller_utils.go:17-21`). We deliberately do **not** fold
+  resolved content into it — that would be the auto-roll behavior we rejected.
+- **The restart path (reuses existing machinery, no new roll engine).** The
+  template hash **does** include template metadata, so changing an annotation on
+  the Workload template changes the Instance template hash, and the stateful
+  strategy already performs an in-place, descending-ordinal, wait-for-Ready rolling
+  update when the stored hash differs (`stateful/stateful_control.go:129-139`,
+  ordering at `:171-172`; `needsUpdate` at `stateful_control_util.go:11-13`). The
+  feature: a convention annotation (e.g. `compute.datumapis.com/restartedAt`) on the
+  Workload template that flows `Workload → WorkloadDeployment → Instance` and forces
+  exactly this roll. Setting/bumping it (by the user, or by an operator/automation
+  after a known rotation) rolls every instance, which re-reads the freshly
+  re-materialized companion. This is the entire restart mechanism — a documented
+  annotation plus the rolls compute already does. (An opt-in *auto*-roll — fold a
+  content hash in behind a per-Workload flag — remains a possible future addition,
+  not part of this RFC.)
+
+## Alternatives considered
+
+- **Inline resolved values into the Instance spec in the management plane.**
+  Simplest delivery (no companion objects, no gate). **Rejected:** leaks secret
+  bytes into etcd on every plane and into the user-visible projected Instance —
+  violates principle 2. Also breaks the immutability/diff model.
+- **Scoped per-project provider read at the edge (no companions).** The strongest
+  alternative, raised in review: give the provider a per-project scoped client (in
+  the spirit of the quota client) so it reads the referenced ConfigMaps/Secrets
+  directly from the project plane and resolves at the edge. *Steelman:* it deletes
+  most of this design — no companion materialization, no ref-counting, no
+  PropagationPolicy extension, no data scheduling gate, no cell-side gate-clearing
+  reconciler; rotation becomes "re-read," and it is far less to ship first. It is
+  also how `infra-provider-gcp` already works in its topology. **Rejected for the
+  delivery of secret bytes:** it requires the edge — a shared, lower-trust plane
+  that runs many tenants' instances — to hold a credential that can read project
+  ConfigMaps/Secrets. Even scoped per-project, that widens edge blast radius for the
+  most sensitive payload, and the resolution boundary (broad project-secret read
+  stays in the management plane) is the whole point of principle 3. The leanness
+  doesn't justify moving secret read to the edge. *(Considered for a config-only
+  hybrid — ConfigMaps via edge read, Secrets via companions — but rejected to avoid
+  maintaining two delivery mechanisms and two failure-mode sets for one feature.)*
+- **Reuse the quota per-project client to read project Secrets from the edge.**
+  **Rejected / not possible:** that client hits a Milo path serving only quota
+  resources, not core Secrets ([memory: quota client is quota-scoped]).
+- **Propagate the user's original objects via Karmada directly (no companion).**
+  **Rejected:** couples cell namespace contents to arbitrary project objects,
+  loses the labeling/scoping boundary, and complicates rotation/cleanup.
+- **A separate controller for pull-secrets, parallel to this one.** **Rejected:**
+  same collect→materialize→propagate→gate machinery. Since this ships first and
+  general, image-pull-credentials becomes a thin consumer (add `imagePullSecrets`
+  to the collected reference set, reuse the gate and scoped client) rather than a
+  parallel cross-plane system.
+- **Env-only, skip file mounts entirely.** Viable as Phase 1 scope, but the API
+  already models volumes and users will expect config files/TLS; designing
+  delivery once (provider-agnostic) keeps Phase 2 cheap.
+
+## Security considerations
+
+- **Bytes never in user-visible specs.** Workload/Instance specs and the projected
+  Instance carry references only. Resolved values exist as Secret objects in
+  `ns-{project-uid}` (project plane, hub, cell) and — for env — in the downstream
+  kraftlet Pod, which is infra-internal and not projected to users.
+- **Companion Secrets are Secrets end-to-end**, never ConfigMaps, never inlined.
+  ConfigMap companions carry only non-secret config.
+- **Scoped read grant.** The resolver's project-plane client needs
+  `get`/`list`/`watch` on `configmaps` and `secrets` in project namespaces —
+  scope this via Milo IAM exactly as image-pull-credentials scopes pull-secret
+  read. No broader access than required.
+- **Cell namespace isolation.** Companions land in the per-project `ns-{uid}`
+  namespace, so one project cannot read another's data on a shared cell.
+- **Authorization at admission (mechanism confirmed).** Per principle 7, admission
+  runs a `SubjectAccessReview` confirming the Workload author can `get` each
+  referenced ConfigMap/Secret in their own namespace. The Network check already
+  does exactly this with the *submitter's* identity — it builds the SAR from
+  `opts.AdmissionRequest.UserInfo` (`Username`/`Groups`/`UID`/`Extra`)
+  (`instance_validation.go:113-131`), so the pattern transfers directly: same
+  `UserInfo`, verb `get`, resources `configmaps`/`secrets`, name from the reference,
+  namespace = the Workload's. This is the gate that prevents a user from naming an
+  object they couldn't read themselves; the resolver's system identity is never the
+  authority. The reconcile-time condition (`SourceUnauthorized`) is the backstop,
+  not the primary control.
+- **kraftlet Pod exposure boundary — the sharpest edge.** Inlining secret-derived
+  env into the downstream Pod is the cost of UKC's inline-only `Env`. The Pod is
+  created in the *downstream kraftlet cluster* via the downstream client
+  (`instance_controller.go:80,120-127`), in `ns-{project-uid}`, and is **not** the
+  object the `InstanceProjector` sends back to the project plane (it projects
+  Instances, not Pods). Two obligations make "infra-internal" real rather than
+  asserted: (1) the downstream kraftlet Pod must **never** be written back to the
+  Karmada hub or projected upstream — state this as an invariant and add a test
+  that fails if a Pod with inlined env appears on the hub; (2) anyone with
+  `pods/get` in the downstream `ns-{project-uid}` can read the values, so that
+  namespace's RBAC on the kraftlet cluster must be locked to platform components.
+  If UKC later accepts secret-aware env (resolving a reference rather than a
+  literal), drop the inlining entirely.
+- **Etcd at rest.** Companion Secrets exist in etcd on the project plane, the
+  Karmada hub, and each cell; the inlined kraftlet Pod adds the downstream cluster.
+  This is the same at-rest exposure image-pull-credentials accepts as a trade-off —
+  it presumes etcd encryption-at-rest on every plane. Call that assumption out
+  explicitly and confirm it per environment rather than leaving it implicit.
+
+## Failure modes and UX
+
+- **Referenced object missing in project ns.** Resolver cannot materialize a
+  companion → Instance gate stays held → `ReferencedDataReady=False` with the
+  missing object named. `optional: true` sources are skipped, not held.
+- **Companion not yet landed on cell.** Gate held; condition surfaces "waiting for
+  data on cell". Normal transient state during placement.
+- **Source rotated but instances not rolled.** Stale-by-design (see
+  [rollout gap](#rotation-and-rollout)); surface last-synced `resourceVersion` on
+  the WorkloadDeployment status so it's observable.
+- **File-mount requested on Unikraft (B1 unmet).** Either rejected at admission
+  with a clear message, or accepted with `ReferencedDataReady=False /
+  Reason=FileMountsUnsupported` — decide in [open questions].
+- **Object too large / too many keys.** Bound companion size; reject oversized
+  references with a clear condition rather than failing propagation silently.
+- **Provider can't read companion on cell.** Instance not started;
+  surface a provider condition rather than booting with missing config.
+- **Unauthorized reference.** Author lacks read on a named object → rejected at
+  admission with a clear message, not deferred to a silent reconcile failure.
+- **Gate stuck on name mismatch.** If the cell reconciler's expected companion set
+  disagrees with what landed (naming-scheme drift), the gate never clears.
+  Mitigated by the explicit expected-name list (option (a) above); surface the
+  expected-vs-present diff on the condition so it's diagnosable, not a silent hang.
+- **Single-cluster mode.** Local copy path must be exercised in tests; absence of
+  Karmada must not silently disable delivery.
+
+## File-level change list
+
+**compute (API + management):**
+- `api/v1alpha/instance_types.go` — add `EnvFrom` to `SandboxContainer`; align
+  Secret volume struct naming.
+- `internal/validation/instance_validation.go` — implement secret-volume
+  validation (`:251`), ConfigMap `items` projection (`:341-343`), `EnvFrom` and
+  `Env.ValueFrom` validation, and a `SubjectAccessReview` that the author can read
+  each referenced ConfigMap/Secret (pattern at `:118-141`).
+- `internal/quota/`-style new package — **scoped project-plane client** (B3): a
+  dedicated full-Kubernetes client for reading project-namespace ConfigMaps/Secrets.
+  This RFC owns it; image-pull-credentials reuses it later.
+- `internal/controller/` — **new `ReferencedDataController`**: collect refs, scoped
+  project-plane read, materialize one shared companion per `(kind, source-name)`,
+  stamp the `expected-referenced-data` annotation on the WD, ref-count referencing
+  WDs, finalizer-driven cleanup.
+- `internal/controller/workloaddeployment_federator.go:284-293` — extend the
+  PropagationPolicy `resourceSelectors` to *always* include the `referenced-data`
+  label selector (ordering-race-free).
+- `internal/controller/instancecontrol/scheduling_gates.go` +
+  `stateful_control.go:94-107` — define and add the `referenced-data` gate when the
+  template carries any reference.
+- cell-side reconciler (new gate-clearing logic, beside the quota-gate clear at
+  `instance_controller.go:233`) — wait for exactly the `expected-referenced-data`
+  set, clear the gate, set `ReferencedDataReady` with the Reason enum + events +
+  metrics.
+- restart path: thread a `compute.datumapis.com/restartedAt` template annotation
+  `Workload → WorkloadDeployment → Instance` (template metadata already feeds
+  `ComputeHash`, so the existing roll triggers — no new roll engine).
+- `make manifests generate`; tests including the single-cluster local-copy path.
+
+**unikraft-provider:**
+- `internal/controller/instance_controller.go:58-105` — **honor scheduling gates**
+  (requeue while any gate is present); this RFC owns introducing this.
+- `internal/controller/instance_controller.go:189-195` — honor `Env.ValueFrom` and
+  `EnvFrom` by resolving companion objects via the **upstream (cell)** client and
+  inlining values into the kraftlet Pod `Env`.
+- File mounts: reject/hold pending B1; map to UKC injection field when available.
+
+## What review changed
+
+### Round 2 + sequencing decision (2026-05-31)
+
+A second review (fact-check, implementation/ops, product/strategy) plus a product
+decision that **ConfigMaps/Secrets must ship before image-pull-credentials**
+reshaped the design:
+
+- **Dependency inverted — this RFC is now foundational and self-contained.** It
+  *introduces* the resolver, the scoped project-plane client (B3), provider
+  gate-honoring, and the gate; image-pull-credentials becomes a later consumer.
+  Nothing here waits on that RFC.
+- **Delivery model decided: management-plane companions.** The scoped-edge-read
+  alternative (raised as the strongest hole — it would delete most of the
+  machinery) is now recorded in [Alternatives](#alternatives-considered),
+  steelmanned, and rejected for secret bytes because it widens edge blast radius;
+  the resolution boundary stays in the management plane.
+- **Rotation decided: no auto-roll + an explicit restart path.** Rewritten to reuse
+  the existing in-place ordered roll (template metadata already feeds `ComputeHash`)
+  via a `restartedAt` template annotation — no new roll engine. Auto-roll rejected
+  as a surprising fleet-wide mass-roll; UKC can't update a running instance's env
+  regardless.
+- **Round-2 gaps closed:** fan-out (one hub object, N Karmada replicas);
+  ref-counting + finalizer lifecycle for shared companions; the federator-vs-resolver
+  ordering race (label selector always present); the gate name contract (decided —
+  `expected-referenced-data` annotation propagated on the WD); observability
+  (`ReferencedDataReady` Reason enum + events + metrics); single-cluster local-copy
+  path made explicit; the SAR mechanism confirmed against the Network check
+  (`UserInfo` from the admission request).
+
+### Round 1
+
+The first review round (technical-correctness and security/product) reshaped the
+initial draft:
+
+- **The cell-side gate-clearing reconciler does not exist** and the original draft
+  hand-waved it. Now called out as net-new work, homed in the cell reconciler
+  beside the quota-gate clear, with an explicit **expected-companion-name contract**
+  to avoid a stuck-forever gate from naming drift.
+- **Provider client confusion.** The draft said "resolve on the cell" without
+  noting the provider's two clients. Pinned: companions are read via the
+  **upstream** (cell) client; the downstream kraftlet cluster has no copy.
+- **Downstream-Pod secret exposure** was dismissed as "infra-internal." Hardened
+  into two explicit obligations (never write the Pod back to the hub; lock down
+  downstream RBAC) plus a test, rather than an assertion.
+- **Authorization** was missing entirely. Added a same-namespace constraint and a
+  `SubjectAccessReview` at admission, mirroring the existing Network check, so a
+  user can't name an object they can't read (confused-deputy risk).
+- **Etcd-at-rest** assumption made explicit, consistent with image-pull-credentials.
+- **Product happy-path** narrative added up front; the draft led with the security
+  guarantee rather than what users gain.
+- **Unproven concerns down-weighted:** Karmada multi-kind `resourceSelectors` is a
+  standard feature (one policy, multiple selectors, same placement) and was
+  confirmed workable; the ordering race is genuinely mitigated by the gate; all
+  spot-checked file:line citations held.
+- **Phase 2 / GCP claim corrected.** A follow-up review of `infra-provider-gcp`
+  showed it mounts ConfigMaps/Secrets today (cloud-init `write_files`; Secret
+  Manager + boot script) but does **not** use companion delivery — it reads the
+  originals from its upstream and transforms inline. The original "GCP unblocked
+  immediately" line was misleading: what's provider-agnostic is the Instance
+  volume *API*, not the delivery mechanism. Phase 2 was also expanded with the
+  precise UKC capability gap (no `files`/`user_data`/volume-content API), the
+  recommended upstream ask, the projected-volume fidelity target, and a
+  workaround analysis concluding none is an acceptable platform answer.
+
+## Decided (previously open)
+
+- **Delivery model:** management-plane companions (not scoped-edge-read). See
+  [Alternatives](#alternatives-considered).
+- **Rotation:** no auto-roll; explicit restart via a `restartedAt` template
+  annotation. See [Rotation and rollout](#rotation-and-rollout).
+- **Gate name contract:** explicit `expected-referenced-data` annotation propagated
+  on the WorkloadDeployment, not recomputed names.
+- **One resolver, not two:** this RFC builds the general resolver; pull secrets are
+  a later consumer.
+- **Sequencing:** ships before image-pull-credentials; this RFC owns the scoped
+  client and provider gate-honoring.
+
+## Open questions for human decision
+
+1. **File-mount UX under B1:** reject at admission, or accept-and-hold with a
+   clear condition (`FileMountsUnsupported`)? Reject is honest; hold lets the same
+   Workload "just work" once UKC ships injection.
+2. **Scoped project-plane client (B3) granularity:** can Milo IAM scope the
+   resolver's read to specific types/labels per project namespace, or is it broad
+   `configmaps,secrets: [get,list,watch]`? This RFC owns building the client;
+   image-pull-credentials inherits whatever scoping is chosen here.
+3. **Companion size/key limits** and behavior on breach (per-object and aggregate
+   across a WorkloadDeployment fanned out to N cells).
+4. **Does `EnvFrom` belong in v1 of this work**, or is per-key `ValueFrom`
+   sufficient for the first release?
+5. **VM runtime (`VirtualMachineRuntime`)** consumption is out of scope for the
+   Unikraft provider (sandbox-only today) — confirm deferral.

--- a/docs/compute/development/rfcs/configmap-secret-mounts.md
+++ b/docs/compute/development/rfcs/configmap-secret-mounts.md
@@ -4,7 +4,7 @@ status: proposed
 
 # Mounting ConfigMaps and Secrets into Compute Instances (Unikraft Provider)
 
-> Drafted 2026-05-30, revised 2026-05-31. **This is the foundational referenced-data delivery design for compute, and it ships before [Image Pull Credentials](./image-pull-credentials.md)** — it introduces the resolver, the scoped project-plane client, companion delivery, and the scheduling gate; pull secrets become a later consumer of the same path.
+> Drafted 2026-05-30, revised 2026-05-31. **This is the foundational referenced-data delivery design for compute, and it ships before [Image Pull Credentials](./image-pull-credentials.md)** — it introduces the resolver, companion delivery, and the scheduling gate; pull secrets become a later consumer of the same path.
 
 ## Table of Contents
 
@@ -14,14 +14,14 @@ status: proposed
 - [The two hops](#the-two-hops)
 - [Design](#design)
   - [Phase 1 — env injection (ships first)](#phase-1--env-injection-ships-first)
-  - [Phase 2 — file mounts (blocked on UKC)](#phase-2--file-mounts-blocked-on-ukc)
+  - [Phase 2 — file mounts (blocked on Unikraft Cloud)](#phase-2--file-mounts-blocked-on-unikraft-cloud)
   - [The referenced-data resolver](#the-referenced-data-resolver)
   - [Scheduling gate and consumption](#scheduling-gate-and-consumption)
   - [Rotation and restart](#rotation-and-restart)
 - [Security](#security)
 - [Alternatives](#alternatives)
 - [Failure modes](#failure-modes)
-- [File-level changes](#file-level-changes)
+- [What gets built](#what-gets-built)
 - [Decisions](#decisions)
 - [Open questions](#open-questions)
 
@@ -29,45 +29,48 @@ status: proposed
 
 ## Summary
 
-A compute `Workload` can already *describe* config/secret mounts — the Instance API
-has `Volumes[].ConfigMap/.Secret` (`instance_types.go:292,296`), `VolumeAttachments`
-with a `MountPath` (`:206`), and `Env` that parses `ValueFrom` (`:139`). But
-describing a mount is all that works. Two independent hops are broken:
+A compute `Workload` can already *describe* config and secret mounts: a volume
+sourced from a ConfigMap or Secret, a container attachment with a mount path, and
+environment variables that reference a key. But describing a mount is all that works
+today. Two independent hops are broken:
 
-1. **Delivery (ours to fix).** The referenced object lives in the user's project
-   namespace; the Instance runs on an edge cell. Federation's `PropagationPolicy`
-   carries **only `WorkloadDeployment`** (`workloaddeployment_federator.go:284-293`),
-   so the data never reaches the cell.
-2. **Consumption (split).** Env injection maps onto UKC's inline `Env` and is
-   **buildable now**. File mounts need a UKC file-injection API that **does not
-   exist** — the same shape of blocker as the registry-auth gap.
+1. **Delivery (ours to fix).** The referenced ConfigMap/Secret lives in the user's
+   project; the instance runs on an edge cell. Federation propagates only the
+   `WorkloadDeployment`, so the data never reaches the cell — the instance comes up
+   referencing data that isn't there.
+2. **Consumption (split).** Surfacing keys as environment variables maps onto what
+   Unikraft Cloud already accepts and is **buildable now**. Mounting data as files
+   needs a file-injection capability Unikraft Cloud **does not have yet** — the same
+   shape of blocker as private-registry credentials.
 
 This RFC keeps the user contract unchanged (create a ConfigMap/Secret, reference it
-by name), resolves it in the management plane, and delivers it to the edge as a
-companion object — secret bytes **never enter the Instance spec**. Env injection
-ships first; file mounts ship when Unikraft Cloud can accept file content.
+by name), resolves the reference in the trusted management plane, and delivers the
+data to the edge as a derived companion object — secret bytes **never enter the
+Workload or Instance spec**. Environment-variable injection ships first; file mounts
+ship when Unikraft Cloud can accept file content.
 
 ## What this enables for users
 
-Today users can only set literal env vars, so config and credentials get baked into
-images or pasted as plaintext. After this:
+Today users can only set literal environment variables, so configuration and
+credentials get baked into images or pasted in as plaintext. After this:
 
 - A user creates a `ConfigMap` and `Secret` in their project and references them
-  from the Workload template; the platform delivers the data to every instance in
-  every POP cell, without the user knowing federation exists.
-- **Secrets stay secret** — values never land in the Workload/Instance spec or the
-  projected Instance; they travel only as Secret objects.
-- **Phase 1 (env):** keys surface as environment variables — the twelve-factor
-  case, no vendor dependency, so it ships first.
+  from the Workload; the platform delivers that data to every instance in every POP
+  cell, without the user ever knowing federation exists.
+- **Secrets stay secret** — values never appear in the Workload or Instance the user
+  sees; they travel only as Secret objects.
+- **Phase 1 (env):** keys surface as environment variables — the twelve-factor case,
+  with no vendor dependency, so it ships first.
 - **Phase 2 (files):** a ConfigMap/Secret mounts as files at a path — for config
-  files and certs. Same API; lands when Unikraft Cloud supports file injection.
+  files and certificates. Same API; lands when Unikraft Cloud supports file
+  injection.
 
 ## End-to-end flow
 
-Phase 1, the decided design (management-plane resolution → companion → Karmada →
-cell → provider). Management-plane controllers: `WorkloadReconciler`,
-`ReferencedDataController`, `WorkloadDeploymentFederator`. The edge cell and the
-compute provider run on the POP cell.
+Phase 1, the decided design: management-plane resolution → companion object →
+federation → cell → provider. The `WorkloadReconciler`, `ReferencedDataController`,
+and `Federator` run in the management plane; the edge cell and the compute provider
+run on the POP cell.
 
 ```mermaid
 sequenceDiagram
@@ -83,214 +86,193 @@ sequenceDiagram
 
     User->>P: 1. Create ConfigMap + Secret
     User->>P: 2. Create Workload referencing them
-    Note over P: Admission SubjectAccessReview —<br/>author may read referenced objects
-    WC->>P: 3. Create WorkloadDeployment per placement<br/>(template copied verbatim)
-    RDC->>P: 4. Read referenced ConfigMap/Secret<br/>(scoped project-plane client)
-    RDC->>K: 5. Materialize labeled companion in ns-{project-uid}
-    RDC->>P: 6. Annotate WD with expected-referenced-data set
-    F->>K: 7. Replicate WD + PropagationPolicy<br/>(city-code + referenced-data selectors)
-    K->>C: 8. Propagate WD + companions to matching cell
-    C->>C: 9. Create Instance with referenced-data gate<br/>(+ network, quota gates)
-    C->>C: 10. Companions present? clear gate,<br/>ReferencedDataReady=True
-    PR->>C: 11. Gate cleared — read companion (cell client)
-    Note over PR: Resolve Env valueFrom/envFrom to values<br/>(bytes only in the downstream Pod, never the Instance)
-    PR->>U: 12. Create kraftlet Pod with inline Env
+    Note over P: Admission check —<br/>author may read the referenced objects
+    WC->>P: 3. Create a WorkloadDeployment per placement
+    RDC->>P: 4. Read referenced ConfigMap/Secret (scoped, trusted)
+    RDC->>K: 5. Materialize a companion copy in the project's federation namespace
+    RDC->>P: 6. Record the expected companion set on the WorkloadDeployment
+    F->>K: 7. Replicate the WorkloadDeployment + routing policy
+    K->>C: 8. Propagate the deployment + companions to each matching cell
+    C->>C: 9. Create the Instance, held by a referenced-data gate
+    C->>C: 10. Companions present? clear the gate, mark data ready
+    PR->>C: 11. Gate cleared — read the companion locally
+    Note over PR: Resolve references to values<br/>(bytes only here, never in the Instance the user sees)
+    PR->>U: 12. Launch the instance with the values applied
     U-->>User: 13. Instance running with config/secret applied
 ```
 
 ## The two hops
 
-**Hop 1 — delivery (ours).** Get the referenced data from the project namespace to
-`ns-{project-uid}` on each placed cell, hold the Instance until it lands.
+**Hop 1 — delivery (ours).** Move the referenced data from the user's project to
+each cell where the workload is placed, and hold the instance until it arrives.
 
-**Hop 2 — consumption.** Env injection lands in UKC's inline `Env` (buildable now).
-File mounts are blocked: UKC's `CreateInstanceRequest` exposes `Env`, `Args`, and
-`Volumes` (references to empty, pre-created disks) — **no `files`/`user_data`/
-metadata field, and no API to put bytes into a volume**. kraftlet's CRD spec *is*
-`CreateInstanceRequest`, so it never reads Pod volumes. This is **B1**: Unikraft
-Cloud must add file injection (recommended ask: a `files` array of
-`{path, content, mode}` on `CreateInstanceRequest`, mirroring cloud-init
-`write_files`). Until then, file mounts are rejected/held on the Unikraft provider.
+**Hop 2 — consumption.** Environment variables map onto what Unikraft Cloud's
+instance API already accepts. File mounts do not: that API accepts environment
+variables and references to pre-created, empty volumes, but offers **no way to inject
+file content or populate a volume with data**. This is **B1** — Unikraft Cloud must
+add file injection (recommended ask: accept a set of files, each with a path,
+content, and mode, at instance-create time). Until then, file mounts are
+rejected or held on the Unikraft provider; the user-facing API is identical, so
+nothing changes for users when the capability lands.
 
 ## Design
 
 ### Phase 1 — env injection (ships first)
 
-Surface ConfigMap/Secret keys as environment variables.
+Surface ConfigMap/Secret keys as environment variables inside the instance. Per-key
+references already exist in the API; add the bulk "import all keys" form to match
+what users expect. The provider reads the delivered companion on the cell, resolves
+the references to concrete values, and passes them to the instance as environment
+variables.
 
-- **API.** `ValueFrom` already parses. Add `EnvFrom []EnvFromSource` to
-  `SandboxContainer` for the bulk form; validate `ValueFrom`/`EnvFrom`
-  (`instance_validation.go`).
-- **Consumption (provider).** The provider holds an **upstream** (cell) client and
-  a **downstream** (kraftlet) client (`instance_controller.go:64-68,80`). Companions
-  land on the cell, so the provider reads them via the upstream client, resolves
-  `ValueFrom`/`EnvFrom` to values, and inlines them into the kraftlet Pod's `Env`
-  (`:189-195`, which today copies only `env.Value`) — not via Pod `ValueFrom` refs,
-  which kraftlet doesn't resolve.
+### Phase 2 — file mounts (blocked on Unikraft Cloud)
 
-### Phase 2 — file mounts (blocked on UKC)
+A user sources a volume from a ConfigMap/Secret and attaches it at a mount path; the
+data renders as files — the familiar contract of selecting specific keys to paths,
+setting file mode, and marking a source optional. This is **provider-agnostic API
+work that can land now** (completing validation for secret volumes, key→path
+selection, and file mode), even though consumption on Unikraft is blocked on B1.
 
-User writes `Volumes[].ConfigMap/.Secret` + `VolumeAttachments[].MountPath`; data
-renders as files (key→path, `items`, `defaultMode`, `optional`, read-only) — the
-standard Kubernetes projected-volume contract.
+That the API is a portable contract is already proven: the GCP provider mounts
+ConfigMaps and Secrets as files today. It does so by reading the originals from its
+own environment rather than using companions — its topology already sits next to
+them — which is why the companion mechanism is specific to the federated edge, not
+universal.
 
-- **API gaps to close now (provider-agnostic).** Implement secret-volume validation
-  (`instance_validation.go:251`), ConfigMap/Secret `items` projection (forbidden at
-  `:341-343`), `defaultMode`/path-safety checks.
-- **Reference consumption.** `infra-provider-gcp` already mounts these — ConfigMap →
-  cloud-init `write_files`, Secret → Secret Manager + boot script
-  (`instance_controller.go:693-731,733-998`) — proving the compute *API* is a
-  portable contract. (GCP reads originals from its own upstream rather than using
-  companions, because its topology already sits next to them; `items` and env
-  `valueFrom` are still TODO there too, `:441`.)
-- **Consumption on UKC is blocked on B1.** No acceptable interim workaround:
-  base64-env-into-files needs wrapping the user's image and pushes secrets through
-  env; pre-populated volumes have no API; baking into the image is the status quo
-  this replaces.
+No interim workaround is acceptable on Unikraft: encoding files into environment
+variables requires wrapping the user's image and pushes secret bytes through the
+environment; pre-populating a volume has no API; baking config into the image is the
+status quo this feature replaces.
 
 ### The referenced-data resolver
 
-A new management-plane `ReferencedDataController`:
+A new management-plane controller is the heart of delivery. For each
+WorkloadDeployment it:
 
-1. **Collect** every referenced ConfigMap/Secret from the WD template
-   (`Env.ValueFrom`, `EnvFrom`, `Volumes`; later `imagePullSecrets`).
-2. **Read** via the scoped project-plane client (B3 — this RFC builds it; not the
-   quota client, which serves only quota resources).
-3. **Materialize** one labeled companion per `(kind, source-name)` in
-   `ns-{project-uid}` (`compute.datumapis.com/referenced-data`).
-4. **Annotate** the WD with `compute.datumapis.com/expected-referenced-data` (the
-   gate contract — propagated to the cell, not reverse-engineered).
-5. **Federate.** The federator's PropagationPolicy *always* includes the
-   `referenced-data` label selector, so a companion materialized after the policy is
-   still picked up — closing the federator-vs-resolver ordering race.
+1. **Collects** every ConfigMap/Secret the template references (env references and
+   volume sources today; image pull secrets later).
+2. **Reads** them with a scoped, trusted project-plane identity — the management
+   plane already has legitimate project access, so broad project-secret read never
+   leaves it.
+3. **Materializes** one labeled companion per referenced object in the project's
+   federation namespace.
+4. **Records** the expected companion set on the WorkloadDeployment, so the cell
+   knows exactly what to wait for rather than guessing.
+5. **Routes** companions to cells by extending the existing federation routing policy
+   to carry the labeled companions alongside the deployment.
 
-**Fan-out:** one hub companion per `(kind, source-name)`; Karmada replicates it to N
-cells — single-write lifecycle. **Ref-counting:** the shared companion tracks
-referencing WDs; a WD finalizer deletes it only when the last reference drops (no
-cross-cluster owner refs — Karmada GC doesn't honor them). **Single-cluster mode:**
-resolver still runs; companion is a local copy, gate clears locally.
+One companion exists per referenced object and is replicated to each placed cell —
+a single object to create, update, and delete. When several deployments reference
+the same object the companion is shared and reference-counted, removed only when the
+last reference goes away. In single-cluster mode the same resolver runs and the
+companion is simply a local copy.
 
 ### Scheduling gate and consumption
 
-- Add a `compute.datumapis.com/referenced-data` gate at instance creation
-  (`stateful_control.go:94-107`) when the template carries any reference.
-- **Clearing (new cell-side logic, beside the quota-gate clear at
-  `instance_controller.go:233`):** wait for exactly the `expected-referenced-data`
-  set, then clear and set `ReferencedDataReady`.
-- **Observability:** `ReferencedDataReady` with explicit Reasons (`Resolving`,
-  `AwaitingPropagation`, `SourceNotFound`/`SourceUnauthorized`/`SourceTooLarge`,
-  `NameMismatch`, `FileMountsUnsupported`, `Ready`) + events + metrics.
-- The **provider must honor gates** — today it creates Pods without checking
-  `Spec.Controller.SchedulingGates` (`instance_controller.go:58-105`). This RFC adds
-  gate-honoring.
+An instance that references any ConfigMap/Secret is held by a **referenced-data
+scheduling gate**, alongside the existing network and quota gates. The cell clears
+it once exactly the expected companion set is present, and surfaces a
+`ReferencedDataReady` status with clear reasons — resolving, awaiting propagation,
+source not found, source unauthorized, source too large, file mounts unsupported, or
+ready — backed by events and metrics so a held instance is diagnosable, not a silent
+hang. The compute provider must respect scheduling gates so an instance is never
+launched with its data missing; this RFC adds that behavior.
 
 ### Rotation and restart
 
-Decided: **no auto-roll; explicit restart.** The resolver re-reads sources and
-re-materializes the companion on change (latest bytes staged at the edge), but
-running instances are not auto-rolled — a fleet-wide mass-roll on every edit is
-surprising, and UKC can't mutate a running instance's env anyway.
+Decided: **no automatic roll; an explicit restart instead.** When a source changes,
+the resolver re-reads it and refreshes the companion, so the latest values are staged
+at the edge for the next instance launch. Running instances are not rolled
+automatically — a fleet-wide restart on every edit is surprising, and Unikraft Cloud
+can't change a running instance's environment anyway.
 
-Content is deliberately **not** folded into the template hash. The restart reuses
-existing machinery: template metadata *is* in `ComputeHash` (`controller_utils.go:17-21`),
-and the stateful strategy already does an in-place, descending-ordinal,
-wait-for-Ready roll when the hash changes (`stateful_control.go:129-139,171-172`).
-So a `compute.datumapis.com/restartedAt` template annotation, threaded
-`Workload → WD → Instance`, triggers that roll — no new roll engine. (Opt-in
-auto-roll via a content hash is a possible future addition.)
+Compute already performs ordered, in-place rolling updates when a Workload's template
+changes. The restart reuses that: a conventional restart annotation on the template
+rolls the instances, which pick up the refreshed values — no new machinery. An
+opt-in automatic roll on content change is a possible future addition, not part of
+this RFC.
 
 ## Security
 
-- **Bytes never in user-visible specs.** Workload/Instance specs and the projected
-  Instance carry references only. Values live as Secret objects in `ns-{project-uid}`
-  and — for env — in the downstream kraftlet Pod (infra-internal, not projected).
-- **Companion Secrets stay Secrets** end-to-end; ConfigMap companions carry only
+- **Bytes never in user-visible specs.** The Workload and the Instance the user sees
+  carry references only. Values exist as Secret objects in the project's federation
+  namespace and, for environment injection, momentarily inside the provider's
+  internal launch request — never in anything projected back to the user.
+- **Companion Secrets stay Secrets** end to end; ConfigMap companions carry only
   non-secret config.
-- **Authorization (mechanism confirmed).** Admission runs a `SubjectAccessReview`
-  for the *submitter* (`AdmissionRequest.UserInfo`) on `get` of each referenced
-  object — a direct copy of the Network check (`instance_validation.go:113-131`).
-  Prevents naming an object the author couldn't read; the resolver's system identity
-  is never the authority.
-- **kraftlet Pod boundary.** Inlined env is the cost of UKC's inline-only `Env`. Two
-  obligations: the downstream Pod must never be written back to the hub (invariant +
-  test), and downstream `ns-{project-uid}` RBAC must be locked to platform
-  components. If UKC adds secret-aware env, drop the inlining.
-- **Etcd at rest.** Companions exist in etcd on project plane, hub, and each cell;
-  presumes encryption-at-rest per plane (same trade-off as image-pull-credentials).
+- **Authorization.** Admission verifies the submitting user can read each referenced
+  object — the same check already used for referenced Networks. A user cannot pull in
+  an object they couldn't read themselves; the resolver's system identity is never
+  the authority.
+- **Trust boundary at the edge.** Resolving in the management plane is deliberate, so
+  the shared, lower-trust edge never holds a credential that can read project
+  ConfigMaps/Secrets. Companions are isolated per project namespace on each cell.
+- **At rest.** Companions live in storage on the project plane, the hub, and each
+  cell; this presumes encryption at rest on every plane.
 
 ## Alternatives
 
-- **Scoped per-project provider read at the edge (no companions).** Strongest
-  alternative — deletes most of this machinery (no companions, ref-counting, PP
-  extension, data gate) and is how GCP already works. **Rejected for secret bytes:**
-  it requires the shared, lower-trust edge to hold a credential that reads project
-  ConfigMaps/Secrets; the resolution boundary staying in the management plane is the
-  point. (A config-only hybrid was considered and rejected to avoid two delivery
-  mechanisms.)
-- **Inline resolved values into the Instance spec.** Rejected — leaks secret bytes
-  into etcd everywhere and into the projected Instance.
+- **Let the provider read the originals from the edge (no companions).** The leanest
+  option — it removes the resolver, companions, routing changes, and the data gate,
+  and it is how the GCP provider already works. **Rejected for secret bytes:** it
+  requires the shared edge to hold a credential that reads project ConfigMaps and
+  Secrets, exactly the trust boundary this design keeps in the management plane. (A
+  config-only hybrid was considered and rejected to avoid maintaining two delivery
+  paths.)
+- **Inline resolved values into the Instance.** Rejected — leaks secret bytes into
+  storage everywhere and into what the user sees.
 - **Propagate the user's original objects directly.** Rejected — couples cell
-  contents to arbitrary project objects, loses the scoping boundary.
-- **A separate controller for pull-secrets.** Rejected — same machinery; pull
-  secrets become a thin consumer of this resolver.
+  contents to arbitrary project objects and loses the scoping boundary.
+- **A separate controller for pull secrets.** Rejected — same machinery; pull secrets
+  become a thin consumer of this resolver instead.
 
 ## Failure modes
 
-- **Source missing/unauthorized/too large** → gate held, `ReferencedDataReady=False`
-  naming the object; `optional` sources skipped.
-- **Companion not yet on cell** → gate held (`AwaitingPropagation`), normal transient
-  state.
-- **Source rotated, instances not rolled** → stale-by-design; surface last-synced
-  `resourceVersion` on WD status.
-- **File mount on Unikraft (B1 unmet)** → reject at admission or hold with
-  `FileMountsUnsupported` (open question), distinct from "still propagating".
-- **Single-cluster mode** → local-copy path must be tested; absence of Karmada must
-  not silently disable delivery.
+- **Source missing, unauthorized, or too large** → gate held, status names the
+  offending object; optional sources are skipped.
+- **Companion not yet on the cell** → gate held (awaiting propagation); a normal
+  transient state during placement.
+- **Source changed, instances not rolled** → stale by design until restarted;
+  last-synced state is surfaced so it's observable.
+- **File mount requested on Unikraft (B1 unmet)** → rejected at admission or held with
+  a clear "file mounts unsupported" reason, distinct from "still propagating."
+- **Single-cluster mode** → the local-copy path must be exercised so the absence of
+  federation never silently disables delivery.
 
-## File-level changes
+## What gets built
 
-**compute (API + management):**
-- `api/v1alpha/instance_types.go` — add `EnvFrom`; align Secret volume struct naming.
-- `internal/validation/instance_validation.go` — secret-volume validation (`:251`),
-  `items` projection (`:341-343`), `EnvFrom`/`ValueFrom` validation, and the
-  referenced-object `SubjectAccessReview` (pattern at `:113-131`).
-- new package — **scoped project-plane client** (B3); reused later by
-  image-pull-credentials.
-- `internal/controller/` — **new `ReferencedDataController`**: collect, read,
-  materialize one shared companion per `(kind, source-name)`, annotate the WD,
-  ref-count, finalizer cleanup.
-- `internal/controller/workloaddeployment_federator.go:284-293` — PropagationPolicy
-  always includes the `referenced-data` selector.
-- `instancecontrol/scheduling_gates.go` + `stateful_control.go:94-107` — define/add
-  the gate; cell-side clearing beside `instance_controller.go:233` with
-  `ReferencedDataReady` + reasons/events/metrics.
-- restart annotation `compute.datumapis.com/restartedAt` threaded
-  `Workload → WD → Instance`.
-- `make manifests generate`; tests including the single-cluster path.
-
-**unikraft-provider:**
-- `internal/controller/instance_controller.go:58-105` — honor scheduling gates.
-- `:189-195` — resolve `ValueFrom`/`EnvFrom` via the cell client; inline into the
-  kraftlet Pod `Env`.
-- File mounts: reject/hold pending B1.
+- A **referenced-data resolver** in the management plane: collect, read, materialize,
+  reference-count, and clean up companions.
+- A **scoped project-plane read identity** for the resolver (built here; reused later
+  by image pull credentials).
+- **Federation routing** extended to carry companions to the same cells as the
+  deployment.
+- A **referenced-data scheduling gate**, cell-side clearing, and the
+  `ReferencedDataReady` status with reasons, events, and metrics.
+- **API additions**: the bulk env-import form, and completing volume validation
+  (secret volumes, key→path selection, file mode) for Phase 2.
+- **Provider changes**: respect scheduling gates, and resolve references into instance
+  environment variables.
+- A **restart** path (a conventional template annotation) so a rotated source can be
+  picked up on demand.
 
 ## Decisions
 
-- **Delivery:** management-plane companions (not scoped-edge-read).
-- **Rotation:** no auto-roll; explicit `restartedAt` restart.
-- **Gate contract:** explicit `expected-referenced-data` annotation, not recomputed
-  names.
+- **Delivery:** management-plane companions (not edge-read).
+- **Rotation:** no auto-roll; explicit restart.
+- **Gate contract:** an explicit expected-companion set recorded on the deployment,
+  not guessed.
 - **One resolver, not two:** pull secrets are a later consumer.
-- **Sequencing:** ships before image-pull-credentials; owns the scoped client and
-  provider gate-honoring.
+- **Sequencing:** ships before image pull credentials; owns the scoped read identity
+  and provider gate-honoring.
 
 ## Open questions
 
-1. **File-mount UX under B1:** reject at admission, or accept-and-hold with
-   `FileMountsUnsupported`?
-2. **Scoped client granularity:** can Milo IAM scope the resolver's read to
-   types/labels per project namespace, or is it broad `configmaps,secrets:[get,list,watch]`?
-3. **Companion size/key limits** and behavior on breach.
-4. **`EnvFrom` in v1**, or per-key `ValueFrom` only for the first release?
+1. **File-mount UX under B1:** reject at admission, or accept and hold with a clear
+   reason?
+2. **Scoped-read granularity:** can the resolver's project read be scoped to specific
+   object types or labels, or is it broad config/secret read?
+3. **Companion size limits** and behavior when exceeded.
+4. **Bulk env import in v1**, or per-key references only for the first release?
 5. **VM runtime** consumption — out of scope for Unikraft (sandbox-only); confirm
    deferral.

--- a/docs/compute/development/rfcs/configmap-secret-mounts.md
+++ b/docs/compute/development/rfcs/configmap-secret-mounts.md
@@ -17,6 +17,7 @@ status: proposed
   - [Consumption on the provider](#consumption-on-the-provider)
   - [Scheduling gate](#scheduling-gate)
   - [Rotation and restart](#rotation-and-restart)
+- [Platform direction](#platform-direction)
 - [Security](#security)
 - [Alternatives](#alternatives)
 - [Failure modes](#failure-modes)
@@ -175,6 +176,43 @@ rolls the instances, which pick up the refreshed values — no new machinery. An
 opt-in automatic roll on content change is a possible future addition, not part of
 this RFC.
 
+## Platform direction
+
+The delivery half of this design — follow references, read them in the trusted
+plane, materialize derived companions, route them to the cells where the resource is
+placed, and signal readiness — is **not specific to compute**. It's a recurring
+platform need: image pull credentials want the same thing next, and the network
+operator already propagates derived Secrets/ConfigMaps to cells by label today. The
+building blocks are already platform-level — the shared namespace-mapping and
+downstream-delivery library, the label-based propagation pattern, and the
+established policy-driven capabilities (quota, activity, insights) that a delivery
+policy would sit naturally beside.
+
+We deliberately **do not** build that generic capability now. With a single consumer
+in hand the abstraction's seams aren't yet known, and a cross-cutting platform
+capability would slow the first ship and widen the security review. Instead, this RFC
+builds toward it on purpose:
+
+- **Build the resolver in compute now, behind a narrow, capability-shaped
+  interface** — in: a subject, its set of referenced objects, and its placement
+  targets; out: companions delivered plus a readiness signal. It reuses the existing
+  platform delivery library rather than inventing its own placement and cleanup.
+- **Keep delivery cleanly separable from consumption.** The scheduling gate and the
+  translation into the runtime's Pod spec stay in compute and depend only on the
+  readiness signal, so the delivery component carries no compute-specific knowledge.
+- **Promote on the second consumer.** When a second user of this pattern appears
+  (image pull credentials, or another service), lift the delivery component into the
+  platform as a capability — most likely an admin-authored delivery policy that
+  declares, per resource kind, which references to follow and where to deliver them,
+  fitting the existing capability-policy pattern. Two real consumers is when the
+  abstraction can be shaped correctly.
+
+This keeps compute shippable and autonomous today while making the design a
+deliberate step toward a shared capability, not a one-off to untangle later. A
+governance benefit falls out: when the policy lands, *what may be propagated, and
+where* becomes an inspectable, access-controlled object rather than logic buried in a
+controller.
+
 ## Security
 
 - **Bytes never in user-visible specs.** The Workload and the Instance the user sees
@@ -246,6 +284,9 @@ this RFC.
 - **Gate contract:** an explicit expected-companion set recorded on the deployment,
   not guessed.
 - **One resolver, not two:** pull secrets are a later consumer.
+- **Platform direction:** build delivery behind a capability-shaped seam in compute
+  now; promote it to a platform-owned, policy-driven capability when a second
+  consumer appears — not before.
 - **Sequencing:** ships before image pull credentials; owns the scoped read identity
   and provider gate-honoring.
 

--- a/docs/compute/development/rfcs/configmap-secret-mounts.md
+++ b/docs/compute/development/rfcs/configmap-secret-mounts.md
@@ -11,12 +11,11 @@ status: proposed
 - [Summary](#summary)
 - [What this enables for users](#what-this-enables-for-users)
 - [End-to-end flow](#end-to-end-flow)
-- [The two hops](#the-two-hops)
+- [The gap: cross-plane delivery](#the-gap-cross-plane-delivery)
 - [Design](#design)
-  - [Phase 1 — env injection (ships first)](#phase-1--env-injection-ships-first)
-  - [Phase 2 — file mounts (blocked on Unikraft Cloud)](#phase-2--file-mounts-blocked-on-unikraft-cloud)
   - [The referenced-data resolver](#the-referenced-data-resolver)
-  - [Scheduling gate and consumption](#scheduling-gate-and-consumption)
+  - [Consumption on the provider](#consumption-on-the-provider)
+  - [Scheduling gate](#scheduling-gate)
   - [Rotation and restart](#rotation-and-restart)
 - [Security](#security)
 - [Alternatives](#alternatives)
@@ -31,23 +30,23 @@ status: proposed
 
 A compute `Workload` can already *describe* config and secret mounts: a volume
 sourced from a ConfigMap or Secret, a container attachment with a mount path, and
-environment variables that reference a key. But describing a mount is all that works
-today. Two independent hops are broken:
+environment variables that reference a key. The runtimes can already *consume* them —
+the Unikraft runtime runs instances from Pod specs through its kubelet integration,
+which honors ConfigMap/Secret references as both environment variables and volume
+mounts, and the GCP provider mounts them as files too. So the API is real and the
+runtimes support it.
 
-1. **Delivery (ours to fix).** The referenced ConfigMap/Secret lives in the user's
-   project; the instance runs on an edge cell. Federation propagates only the
-   `WorkloadDeployment`, so the data never reaches the cell — the instance comes up
-   referencing data that isn't there.
-2. **Consumption (split).** Surfacing keys as environment variables maps onto what
-   Unikraft Cloud already accepts and is **buildable now**. Mounting data as files
-   needs a file-injection capability Unikraft Cloud **does not have yet** — the same
-   shape of blocker as private-registry credentials.
+The one thing missing is in the middle: **the referenced data never reaches the cell
+where the instance runs.** It lives in the user's project; the instance runs on an
+edge cell; federation propagates only the `WorkloadDeployment`. The instance comes up
+referencing data that isn't there.
 
-This RFC keeps the user contract unchanged (create a ConfigMap/Secret, reference it
-by name), resolves the reference in the trusted management plane, and delivers the
-data to the edge as a derived companion object — secret bytes **never enter the
-Workload or Instance spec**. Environment-variable injection ships first; file mounts
-ship when Unikraft Cloud can accept file content.
+This RFC closes that gap. It keeps the user contract unchanged (create a
+ConfigMap/Secret, reference it by name), resolves the reference in the trusted
+management plane, and delivers the data to the edge as a derived companion object —
+secret bytes **never enter the Workload or Instance spec**. Both environment
+variables and file mounts work, because once the data is present the runtime's
+existing Pod-spec consumption handles the rest.
 
 ## What this enables for users
 
@@ -57,20 +56,18 @@ credentials get baked into images or pasted in as plaintext. After this:
 - A user creates a `ConfigMap` and `Secret` in their project and references them
   from the Workload; the platform delivers that data to every instance in every POP
   cell, without the user ever knowing federation exists.
+- **Both forms work** — keys surfaced as environment variables (the twelve-factor
+  case) and ConfigMaps/Secrets mounted as files at a path (config files,
+  certificates).
 - **Secrets stay secret** — values never appear in the Workload or Instance the user
   sees; they travel only as Secret objects.
-- **Phase 1 (env):** keys surface as environment variables — the twelve-factor case,
-  with no vendor dependency, so it ships first.
-- **Phase 2 (files):** a ConfigMap/Secret mounts as files at a path — for config
-  files and certificates. Same API; lands when Unikraft Cloud supports file
-  injection.
 
 ## End-to-end flow
 
-Phase 1, the decided design: management-plane resolution → companion object →
-federation → cell → provider. The `WorkloadReconciler`, `ReferencedDataController`,
-and `Federator` run in the management plane; the edge cell and the compute provider
-run on the POP cell.
+The decided design: management-plane resolution → companion object → federation →
+cell → provider. The `WorkloadReconciler`, `ReferencedDataController`, and
+`Federator` run in the management plane; the edge cell and the compute provider run
+on the POP cell.
 
 ```mermaid
 sequenceDiagram
@@ -95,65 +92,38 @@ sequenceDiagram
     K->>C: 8. Propagate the deployment + companions to each matching cell
     C->>C: 9. Create the Instance, held by a referenced-data gate
     C->>C: 10. Companions present? clear the gate, mark data ready
-    PR->>C: 11. Gate cleared — read the companion locally
-    Note over PR: Resolve references to values<br/>(bytes only here, never in the Instance the user sees)
-    PR->>U: 12. Launch the instance with the values applied
+    PR->>C: 11. Translate the Instance into a Pod spec referencing the companions
+    Note over PR,U: Kubelet integration mounts the volumes and<br/>injects the env vars natively from the present data
+    PR->>U: 12. Launch the instance with config/secret applied
     U-->>User: 13. Instance running with config/secret applied
 ```
 
-## The two hops
+## The gap: cross-plane delivery
 
-**Hop 1 — delivery (ours).** Move the referenced data from the user's project to
-each cell where the workload is placed, and hold the instance until it arrives.
+The referenced ConfigMap/Secret lives in the user's project namespace; the instance
+runs on an edge cell, possibly thousands of miles away. The federation channel
+carries only the `WorkloadDeployment`, so the data has no path to the cell. There is
+also no gate guarding this — the instance isn't even held back; it simply launches
+with the reference unresolved.
 
-**Hop 2 — consumption.** Environment variables map onto what Unikraft Cloud's
-instance API already accepts. File mounts do not: that API accepts environment
-variables and references to pre-created, empty volumes, but offers **no way to inject
-file content or populate a volume with data**. This is **B1** — Unikraft Cloud must
-add file injection (recommended ask: accept a set of files, each with a path,
-content, and mode, at instance-create time). Until then, file mounts are
-rejected or held on the Unikraft provider; the user-facing API is identical, so
-nothing changes for users when the capability lands.
+Consumption is *not* a gap: the Unikraft runtime's kubelet integration already
+resolves ConfigMap/Secret references in a Pod spec — env vars and volume mounts
+alike — provided the referenced objects are present where it resolves them. So the
+whole problem is getting the data to the cell, and faithfully carrying the
+references through into the Pod spec the runtime consumes.
 
 ## Design
-
-### Phase 1 — env injection (ships first)
-
-Surface ConfigMap/Secret keys as environment variables inside the instance. Per-key
-references already exist in the API; add the bulk "import all keys" form to match
-what users expect. The provider reads the delivered companion on the cell, resolves
-the references to concrete values, and passes them to the instance as environment
-variables.
-
-### Phase 2 — file mounts (blocked on Unikraft Cloud)
-
-A user sources a volume from a ConfigMap/Secret and attaches it at a mount path; the
-data renders as files — the familiar contract of selecting specific keys to paths,
-setting file mode, and marking a source optional. This is **provider-agnostic API
-work that can land now** (completing validation for secret volumes, key→path
-selection, and file mode), even though consumption on Unikraft is blocked on B1.
-
-That the API is a portable contract is already proven: the GCP provider mounts
-ConfigMaps and Secrets as files today. It does so by reading the originals from its
-own environment rather than using companions — its topology already sits next to
-them — which is why the companion mechanism is specific to the federated edge, not
-universal.
-
-No interim workaround is acceptable on Unikraft: encoding files into environment
-variables requires wrapping the user's image and pushes secret bytes through the
-environment; pre-populating a volume has no API; baking config into the image is the
-status quo this feature replaces.
 
 ### The referenced-data resolver
 
 A new management-plane controller is the heart of delivery. For each
 WorkloadDeployment it:
 
-1. **Collects** every ConfigMap/Secret the template references (env references and
-   volume sources today; image pull secrets later).
-2. **Reads** them with a scoped, trusted project-plane identity — the management
-   plane already has legitimate project access, so broad project-secret read never
-   leaves it.
+1. **Collects** every ConfigMap/Secret the template references — environment
+   references and volume sources today; image pull secrets later.
+2. **Reads** them with a scoped, trusted project-plane identity. The management plane
+   already has legitimate project access, so broad project-secret read never leaves
+   it.
 3. **Materializes** one labeled companion per referenced object in the project's
    federation namespace.
 4. **Records** the expected companion set on the WorkloadDeployment, so the cell
@@ -161,30 +131,43 @@ WorkloadDeployment it:
 5. **Routes** companions to cells by extending the existing federation routing policy
    to carry the labeled companions alongside the deployment.
 
-One companion exists per referenced object and is replicated to each placed cell —
-a single object to create, update, and delete. When several deployments reference
-the same object the companion is shared and reference-counted, removed only when the
-last reference goes away. In single-cluster mode the same resolver runs and the
-companion is simply a local copy.
+One companion exists per referenced object and is replicated to each placed cell — a
+single object to create, update, and delete. When several deployments reference the
+same object the companion is shared and reference-counted, removed only when the last
+reference goes away. In single-cluster mode the same resolver runs and the companion
+is simply a local copy.
 
-### Scheduling gate and consumption
+### Consumption on the provider
+
+Once the companions are present on the cell, the provider translates the Instance
+into the Pod spec the runtime consumes — carrying the volume sources, volume mounts,
+and environment references through faithfully and pointing them at the delivered
+companions, with the referenced data present in the namespace the runtime resolves
+from. The kubelet integration then mounts the volumes and injects the environment
+variables natively; there is no provider-side inlining of secret values. (The
+provider does not do this faithful translation today — it drops volumes and copies
+only literal env values — so this is the provider-side work this RFC covers. The GCP
+provider performs the equivalent translation already, which is why the same Workload
+runs on either substrate.)
+
+### Scheduling gate
 
 An instance that references any ConfigMap/Secret is held by a **referenced-data
-scheduling gate**, alongside the existing network and quota gates. The cell clears
-it once exactly the expected companion set is present, and surfaces a
+scheduling gate**, alongside the existing network and quota gates. The cell clears it
+once exactly the expected companion set is present, and surfaces a
 `ReferencedDataReady` status with clear reasons — resolving, awaiting propagation,
-source not found, source unauthorized, source too large, file mounts unsupported, or
-ready — backed by events and metrics so a held instance is diagnosable, not a silent
-hang. The compute provider must respect scheduling gates so an instance is never
-launched with its data missing; this RFC adds that behavior.
+source not found, source unauthorized, source too large, or ready — backed by events
+and metrics so a held instance is diagnosable, not a silent hang. The compute
+provider must respect scheduling gates so an instance is never launched with its data
+missing; this RFC adds that behavior.
 
 ### Rotation and restart
 
 Decided: **no automatic roll; an explicit restart instead.** When a source changes,
 the resolver re-reads it and refreshes the companion, so the latest values are staged
 at the edge for the next instance launch. Running instances are not rolled
-automatically — a fleet-wide restart on every edit is surprising, and Unikraft Cloud
-can't change a running instance's environment anyway.
+automatically — a fleet-wide restart on every edit is surprising, and a running
+instance's environment isn't mutated in place regardless.
 
 Compute already performs ordered, in-place rolling updates when a Workload's template
 changes. The restart reuses that: a conventional restart annotation on the template
@@ -196,10 +179,11 @@ this RFC.
 
 - **Bytes never in user-visible specs.** The Workload and the Instance the user sees
   carry references only. Values exist as Secret objects in the project's federation
-  namespace and, for environment injection, momentarily inside the provider's
-  internal launch request — never in anything projected back to the user.
+  namespace and on the cell where the runtime mounts them — never in anything
+  projected back to the user.
 - **Companion Secrets stay Secrets** end to end; ConfigMap companions carry only
-  non-secret config.
+  non-secret config. The runtime mounts the companions directly, so the provider
+  never has to inline secret values itself.
 - **Authorization.** Admission verifies the submitting user can read each referenced
   object — the same check already used for referenced Networks. A user cannot pull in
   an object they couldn't read themselves; the resolver's system identity is never
@@ -234,8 +218,6 @@ this RFC.
   transient state during placement.
 - **Source changed, instances not rolled** → stale by design until restarted;
   last-synced state is surfaced so it's observable.
-- **File mount requested on Unikraft (B1 unmet)** → rejected at admission or held with
-  a clear "file mounts unsupported" reason, distinct from "still propagating."
 - **Single-cluster mode** → the local-copy path must be exercised so the absence of
   federation never silently disables delivery.
 
@@ -249,10 +231,11 @@ this RFC.
   deployment.
 - A **referenced-data scheduling gate**, cell-side clearing, and the
   `ReferencedDataReady` status with reasons, events, and metrics.
-- **API additions**: the bulk env-import form, and completing volume validation
-  (secret volumes, key→path selection, file mode) for Phase 2.
-- **Provider changes**: respect scheduling gates, and resolve references into instance
-  environment variables.
+- **API additions**: a bulk "import all keys" env form, and completing volume
+  validation (secret volumes, key→path selection, file mode).
+- **Provider changes**: respect scheduling gates, and faithfully translate the
+  Instance's volumes, mounts, and env references into the Pod spec the runtime
+  consumes.
 - A **restart** path (a conventional template annotation) so a rotated source can be
   picked up on demand.
 
@@ -268,11 +251,9 @@ this RFC.
 
 ## Open questions
 
-1. **File-mount UX under B1:** reject at admission, or accept and hold with a clear
-   reason?
-2. **Scoped-read granularity:** can the resolver's project read be scoped to specific
+1. **Scoped-read granularity:** can the resolver's project read be scoped to specific
    object types or labels, or is it broad config/secret read?
-3. **Companion size limits** and behavior when exceeded.
-4. **Bulk env import in v1**, or per-key references only for the first release?
-5. **VM runtime** consumption — out of scope for Unikraft (sandbox-only); confirm
+2. **Companion size limits** and behavior when exceeded.
+3. **Bulk env import in v1**, or per-key references only for the first release?
+4. **VM runtime** consumption — out of scope for Unikraft (sandbox-only); confirm
    deferral.


### PR DESCRIPTION
## Summary

Today a compute Workload can only set literal environment variables — users can't point an instance at a ConfigMap or Secret they manage, so app config, API keys, and TLS material end up baked into images or pasted as plaintext. This RFC proposes letting users reference ConfigMaps and Secrets from a Workload template and have that data delivered securely to their instances in every POP cell the workload runs in, without the user ever knowing federation exists.

It splits the work along what's actually achievable:

- **Env injection** (ConfigMap/Secret keys as environment variables) — the common twelve-factor case, deliverable on the Unikraft provider with no upstream vendor dependency, so it ships first.
- **File mounts** (ConfigMap/Secret rendered as files at a path) — needed for config files and certs, but blocked on an Unikraft Cloud file-injection capability that doesn't exist yet. The user-facing API is identical, so there's no rework for users when it lands.

Secret values never enter the Workload or Instance spec; they travel only as Secret objects, resolved in the management plane and delivered to the edge. This RFC also establishes the foundational referenced-data delivery path (resolver, scoped project-plane client, scheduling gate, provider gate honoring) that image pull credentials will later consume rather than rebuild.

The document is the deliverable here — it records the design, the two architecture decisions made (management-plane companion delivery; no auto-roll plus an explicit restart path), the alternatives weighed, and what two rounds of adversarial review changed.

## Review plan

- [ ] Validate the cross-plane delivery model (companions + PropagationPolicy) against federation behavior
- [ ] Confirm the Unikraft Cloud file-injection gap and the proposed upstream ask
- [ ] Sanity-check the security boundary (secret bytes never in user-visible specs; edge exposure)
- [ ] Review the open questions, especially file-mount UX and scoped-client IAM granularity

🤖 Generated with [Claude Code](https://claude.com/claude-code)