### PR TITLE
Enable the ReferencedDataGate feature flag in the lab

### DIFF
--- a/config/overlays/cell/disable_webhook_patch.yaml
+++ b/config/overlays/cell/disable_webhook_patch.yaml
@@ -10,3 +10,5 @@ data:
       bindAddress: "0"
     discovery:
       quotaKubeconfigPath: /etc/quota-credentials/kubeconfig
+    featureFlags:
+      enableReferencedDataGate: true


### PR DESCRIPTION
## Value

Enables the `ReferencedDataGate` feature flag on the lab cell overlay, so referenced ConfigMap/Secret delivery can be exercised in the lab environment.

## What

A single config change to the cell overlay turning the gate on for lab.

(The referenced-data e2e suite that previously rode with this PR has been deferred — see #149 — and removed; this is now just the lab enablement.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
