### PR TITLE
Add the per-project quota client and metrics

### DIFF
--- a/internal/quota/client.go
+++ b/internal/quota/client.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package quota
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ProjectQuotaClientManager builds and caches controller-runtime clients that
+// target individual Milo project control planes. It is safe for concurrent use.
+type ProjectQuotaClientManager struct {
+	baseRestConfig *rest.Config
+	clients        sync.Map // key: projectID (string), value: client.Client
+}
+
+// New returns a ProjectQuotaClientManager that derives per-project REST configs
+// from baseRestConfig by rewriting the host path.
+func New(baseRestConfig *rest.Config) *ProjectQuotaClientManager {
+	return &ProjectQuotaClientManager{baseRestConfig: baseRestConfig}
+}
+
+// StoreClient pre-populates the cache with a pre-built client for projectID.
+// This is intended for use in unit tests where a real REST server is unavailable.
+func (m *ProjectQuotaClientManager) StoreClient(projectID string, cl client.Client) {
+	m.clients.Store(projectID, cl)
+}
+
+// ClientForProject returns a client.Client targeting the Milo project control
+// plane for projectID. The client is constructed once and cached for subsequent
+// calls. scheme must include all types the caller intends to operate on,
+// including quotav1alpha1.
+func (m *ProjectQuotaClientManager) ClientForProject(
+	ctx context.Context,
+	projectID string,
+	scheme *runtime.Scheme,
+) (client.Client, error) {
+	if v, ok := m.clients.Load(projectID); ok {
+		return v.(client.Client), nil
+	}
+
+	cfg := rest.CopyConfig(m.baseRestConfig)
+	apiHost, err := url.Parse(cfg.Host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse base host: %w", err)
+	}
+	apiHost.Path = fmt.Sprintf(
+		"/apis/resourcemanager.miloapis.com/v1alpha1/projects/%s/control-plane",
+		projectID,
+	)
+	cfg.Host = apiHost.String()
+
+	cl, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client for project %q: %w", projectID, err)
+	}
+
+	m.clients.Store(projectID, cl)
+	return cl, nil
+}

--- a/internal/quota/metrics.go
+++ b/internal/quota/metrics.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package quota
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Metric reason label values for quota_eval_failures_total.
+const (
+	ReasonBackendUnavailable    = "backend_unavailable"
+	ReasonProjectNotFound       = "project_not_found"
+	ReasonNamespaceNotFound     = "namespace_not_found"
+	ReasonMisconfigured         = "misconfigured"
+	ReasonProjectIDUnresolvable = "project_id_unresolvable"
+	ReasonNoBudget              = "no_budget"
+)
+
+var (
+	// EnforcementEnabled is a gauge set to 1 when quota enforcement is active
+	// (a credential path is configured) and 0 when disabled (no path configured).
+	// This gives dashboards and alerting a stable signal rather than log scraping.
+	EnforcementEnabled = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "compute_quota_enforcement_enabled",
+		Help: "1 if quota enforcement is active, 0 if disabled (no credential configured).",
+	})
+
+	// EvalFailuresTotal counts quota evaluation failures by reason code.
+	// Incremented each time quota evaluation fails for a reason other than the
+	// normal quota-exceeded or quota-pending flow.
+	EvalFailuresTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "compute_quota_eval_failures_total",
+		Help: "Total quota evaluation failures by reason code.",
+	}, []string{"reason"})
+
+	// ClaimOrphanedTotal counts ResourceClaims orphaned during instance deletion
+	// because the project ID could not be resolved at deletion time.
+	ClaimOrphanedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "compute_quota_claim_orphaned_total",
+		Help: "Total ResourceClaims orphaned because project ID could not be resolved at deletion.",
+	})
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		EnforcementEnabled,
+		EvalFailuresTotal,
+		ClaimOrphanedTotal,
+	)
+}


### PR DESCRIPTION
## Value

Lands the **per-project quota client and metrics** as a self-contained unit, ahead of the controllers that use it. Like the API types, this is scaffolding that stands on its own — it builds and vets cleanly on `main` independently of the federation controllers — so it can be reviewed in isolation before the reconcilers wire it in.

## What

A self-contained `internal/quota` package:
- The per-project quota client (talks to the Milo quota control-plane path)
- Quota metrics

No controllers, no wiring — just the package. The federation foundation consumes it once it lands.

## Stack

Sits between the (merged) API types and the federation foundation: `main ← this ← #107 (controllers/wiring/config) ← …`. Extracted from #107 so the quota integration reviews on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
