### PR TITLE
An Instance is "Available" when it's ready to serve, even when scaled to zero

### DIFF
--- a/api/v1alpha/instance_types.go
+++ b/api/v1alpha/instance_types.go
@@ -404,8 +404,10 @@ const (
 	// InstanceReady indicates that the instance is ready
 	InstanceReady = "Ready"
 
-	// InstanceRunning indicates that the instance is running
-	InstanceRunning = "Running"
+	// InstanceAvailable indicates that the instance is available. It is True
+	// when the instance is serving and does not assert that a process is
+	// actively running at this instant.
+	InstanceAvailable = "Available"
 
 	// InstanceProgrammed indicates that the instance has been programmed
 	InstanceProgrammed = "Programmed"
@@ -458,20 +460,42 @@ const (
 	// InstanceReadyReasonSchedulingGatesPresent indicates that the instance is not ready because scheduling gates are present.
 	InstanceReadyReasonSchedulingGatesPresent = "SchedulingGatesPresent"
 
-	// InstanceReadyReasonRunning indicates that the instance is running
-	InstanceReadyReasonRunning = "Running"
+	// InstanceReadyReasonAvailable indicates that the instance is available
+	InstanceReadyReasonAvailable = "Available"
 
-	// InstanceRunningReasonStopped indicates that the instance is stopped
-	InstanceRunningReasonStopped = "Stopped"
+	// InstanceReadyReasonImageUnavailable indicates the provider could not pull
+	// the instance image (bad name, missing credentials, registry unreachable).
+	// This matches the reason written by translateWaitingReason in the unikraft
+	// provider when the container enters an image-pull waiting state.
+	InstanceReadyReasonImageUnavailable = "ImageUnavailable"
 
-	// InstanceRunningReasonStarting indicates that the instance is starting
-	InstanceRunningReasonStarting = "Starting"
+	// InstanceReadyReasonInstanceCrashing indicates the instance process started
+	// but is repeatedly exiting and being restarted (CrashLoopBackOff in the
+	// underlying runtime). This is user-actionable: the application itself is
+	// failing, not the platform.
+	InstanceReadyReasonInstanceCrashing = "InstanceCrashing"
 
-	// InstanceRunningReasonStopping indicates that the instance is stopping
-	InstanceRunningReasonStopping = "Stopping"
+	// InstanceReadyReasonConfigurationError indicates the runtime rejected the
+	// instance configuration before the process could start (e.g. invalid env
+	// variable injection, missing device). User must correct the workload spec.
+	InstanceReadyReasonConfigurationError = "ConfigurationError"
 
-	// InstanceRunningReasonRunning indicates that the instance is running
-	InstanceRunningReasonRunning = "Running"
+	// InstanceReadyReasonProvisioning indicates the instance runtime is still
+	// setting up the execution environment (container being created, image being
+	// unpacked). This is a transient, non-actionable state.
+	InstanceReadyReasonProvisioning = "Provisioning"
+
+	// InstanceAvailableReasonStopped indicates that the instance is stopped
+	InstanceAvailableReasonStopped = "Stopped"
+
+	// InstanceAvailableReasonStarting indicates that the instance is starting
+	InstanceAvailableReasonStarting = "Starting"
+
+	// InstanceAvailableReasonStopping indicates that the instance is stopping
+	InstanceAvailableReasonStopping = "Stopping"
+
+	// InstanceAvailableReasonAvailable indicates that the instance is available
+	InstanceAvailableReasonAvailable = "Available"
 
 	// InstanceProgrammedReasonPendingProgramming indicates that the instance has not been programmed
 	InstanceProgrammedReasonPendingProgramming = "PendingProgramming"
@@ -515,7 +539,7 @@ type Instance struct {
 
 	// Status defines the current state of an Instance.
 	//
-	// +kubebuilder:default={conditions:{{type:"Programmed",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type:"Running",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type:"Ready",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type:"QuotaGranted",status:"Unknown",reason:"PendingEvaluation",message:"Waiting for quota evaluation",lastTransitionTime:"1970-01-01T00:00:00Z"}}}
+	// +kubebuilder:default={conditions:{{type:"Programmed",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type:"Available",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type:"Ready",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type:"QuotaGranted",status:"Unknown",reason:"PendingEvaluation",message:"Waiting for quota evaluation",lastTransitionTime:"1970-01-01T00:00:00Z"}}}
 	Status InstanceStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha/workload_types.go
+++ b/api/v1alpha/workload_types.go
@@ -58,14 +58,26 @@ type WorkloadStatus struct {
 	// The number of instances that currently exist
 	Replicas int32 `json:"replicas"`
 
-	// The number of instances which have the latest workload settings applied.
+	// The number of instances which have the latest workload settings applied
+	// and are programmed (a subset of UpdatedReplicas that are ready to serve).
 	CurrentReplicas int32 `json:"currentReplicas"`
+
+	// The number of instances updated to the latest template revision (their
+	// observed template hash matches the desired template), regardless of
+	// readiness. Lags Replicas during a rolling update or restart, then catches
+	// back up — making an in-progress roll observable.
+	UpdatedReplicas int32 `json:"updatedReplicas"`
 
 	// The desired number of instances
 	DesiredReplicas int32 `json:"desiredReplicas"`
 
 	// The number of instances which are ready.
 	ReadyReplicas int32 `json:"readyReplicas"`
+
+	// The most recent generation observed by the workload controller.
+	//
+	// +kubebuilder:validation:Optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// The current status of placemetns in a workload.
 	Placements []WorkloadPlacementStatus `json:"placements,omitempty"`
@@ -99,7 +111,7 @@ type WorkloadGatewayStatus struct {
 // +kubebuilder:printcolumn:name="Replicas",type=string,JSONPath=`.status.replicas`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.readyReplicas`
 // +kubebuilder:printcolumn:name="Desired",type=string,JSONPath=`.status.desiredReplicas`
-// +kubebuilder:printcolumn:name="Up-to-date",type=string,JSONPath=`.status.currentReplicas`
+// +kubebuilder:printcolumn:name="Up-to-date",type=string,JSONPath=`.status.updatedReplicas`
 type Workload struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -146,8 +158,13 @@ type WorkloadPlacementStatus struct {
 	// The number of instances that currently exist
 	Replicas int32 `json:"replicas"`
 
-	// The number of instances which have the latest workload settings applied.
+	// The number of instances which have the latest workload settings applied
+	// and are programmed (a subset of UpdatedReplicas that are ready to serve).
 	CurrentReplicas int32 `json:"currentReplicas"`
+
+	// The number of instances updated to the latest template revision, regardless
+	// of readiness. Lags Replicas during a rolling update or restart.
+	UpdatedReplicas int32 `json:"updatedReplicas"`
 
 	// The desired number of instances
 	DesiredReplicas int32 `json:"desiredReplicas"`

--- a/api/v1alpha/workloaddeployment_types.go
+++ b/api/v1alpha/workloaddeployment_types.go
@@ -49,14 +49,28 @@ type WorkloadDeploymentStatus struct {
 	// The number of instances created
 	Replicas int32 `json:"replicas"`
 
-	// The number of instances which have the latest workload settings applied.
+	// The number of instances which have the latest workload settings applied
+	// and are programmed (a subset of UpdatedReplicas that are ready to serve).
 	CurrentReplicas int32 `json:"currentReplicas"`
+
+	// The number of instances updated to the latest template revision, i.e.
+	// whose observed template hash matches the desired template, regardless of
+	// readiness. Lags Replicas during a rolling update or restart, then catches
+	// back up — making an in-progress roll observable.
+	UpdatedReplicas int32 `json:"updatedReplicas"`
 
 	// The desired number of instances
 	DesiredReplicas int32 `json:"desiredReplicas"`
 
 	// The number of instances which are ready.
 	ReadyReplicas int32 `json:"readyReplicas"`
+
+	// The most recent generation observed by the deployment controller. When
+	// this matches metadata.generation, the controller has reconciled the
+	// latest spec (e.g. a restart request).
+	//
+	// +kubebuilder:validation:Optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 const (
@@ -79,7 +93,7 @@ const (
 // +kubebuilder:printcolumn:name="Replicas",type=string,JSONPath=`.status.replicas`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.readyReplicas`
 // +kubebuilder:printcolumn:name="Desired",type=string,JSONPath=`.status.desiredReplicas`
-// +kubebuilder:printcolumn:name="Up-to-date",type=string,JSONPath=`.status.currentReplicas`
+// +kubebuilder:printcolumn:name="Up-to-date",type=string,JSONPath=`.status.updatedReplicas`
 // +kubebuilder:printcolumn:name="Location Namespace",type=string,JSONPath=`.status.location.namespace`,priority=1
 // +kubebuilder:printcolumn:name="Location Name",type=string,JSONPath=`.status.location.name`,priority=1
 type WorkloadDeployment struct {

--- a/config/base/crd/bases/compute.datumapis.com_instances.yaml
+++ b/config/base/crd/bases/compute.datumapis.com_instances.yaml
@@ -35,6 +35,10 @@ spec:
       name: Message
       priority: 1
       type: string
+    - jsonPath: .status.conditions[?(@.type=="QuotaGranted")].reason
+      name: Quota
+      priority: 1
+      type: string
     name: v1alpha
     schema:
       openAPIV3Schema:
@@ -262,6 +266,28 @@ spec:
                         description: A list of containers to run within the sandbox.
                         items:
                           properties:
+                            args:
+                              description: |-
+                                Arguments to the entrypoint, overriding the image's CMD. Combined with
+                                Command: when Command is also set the resulting invocation is
+                                append(Command, Args...).  When only Args is set it overrides CMD while
+                                preserving the image's ENTRYPOINT.
+
+                                If neither Command nor Args is set, the image's own ENTRYPOINT and CMD
+                                are used unchanged.
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: |-
+                                Entrypoint array to run in the container image, overriding the image's
+                                ENTRYPOINT. Each element is a separate token, not a shell command — to run a
+                                shell command use: ["sh", "-c", "my command"].
+
+                                If not provided, the container image's own ENTRYPOINT is used.
+                              items:
+                                type: string
+                              type: array
                             env:
                               description: |-
                                 List of environment variables to set in the container.
@@ -272,8 +298,9 @@ spec:
                                   present in a Container.
                                 properties:
                                   name:
-                                    description: Name of the environment variable.
-                                      Must be a C_IDENTIFIER.
+                                    description: |-
+                                      Name of the environment variable.
+                                      May consist of any printable ASCII characters except '='.
                                     type: string
                                   value:
                                     description: |-
@@ -330,6 +357,43 @@ spec:
                                             type: string
                                         required:
                                         - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        description: |-
+                                          FileKeyRef selects a key of the env file.
+                                          Requires the EnvFiles feature gate to be enabled.
+                                        properties:
+                                          key:
+                                            description: |-
+                                              The key within the env file. An invalid key will prevent the pod from starting.
+                                              The keys defined within a source may consist of any printable ASCII characters except '='.
+                                              During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                            type: string
+                                          optional:
+                                            default: false
+                                            description: |-
+                                              Specify whether the file or its key must be defined. If the file or key
+                                              does not exist, then the env var is not published.
+                                              If optional is set to true and the specified key does not exist,
+                                              the environment variable will not be set in the Pod's containers.
+
+                                              If optional is set to false and the specified key does not exist,
+                                              an error will be returned during Pod creation.
+                                            type: boolean
+                                          path:
+                                            description: |-
+                                              The path within the volume from which to select the file.
+                                              Must be relative and may not contain the '..' path or start with '..'.
+                                            type: string
+                                          volumeName:
+                                            description: The name of the volume mount
+                                              containing the env file.
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
@@ -823,12 +887,17 @@ spec:
                 message: Waiting for controller
                 reason: Pending
                 status: Unknown
-                type: Running
+                type: Available
               - lastTransitionTime: "1970-01-01T00:00:00Z"
                 message: Waiting for controller
                 reason: Pending
                 status: Unknown
                 type: Ready
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for quota evaluation
+                reason: PendingEvaluation
+                status: Unknown
+                type: QuotaGranted
             description: Status defines the current state of an Instance.
             properties:
               conditions:

--- a/config/base/crd/bases/compute.datumapis.com_workloaddeployments.yaml
+++ b/config/base/crd/bases/compute.datumapis.com_workloaddeployments.yaml
@@ -34,7 +34,7 @@ spec:
     - jsonPath: .status.desiredReplicas
       name: Desired
       type: string
-    - jsonPath: .status.currentReplicas
+    - jsonPath: .status.updatedReplicas
       name: Up-to-date
       type: string
     - jsonPath: .status.location.namespace
@@ -375,6 +375,28 @@ spec:
                                   sandbox.
                                 items:
                                   properties:
+                                    args:
+                                      description: |-
+                                        Arguments to the entrypoint, overriding the image's CMD. Combined with
+                                        Command: when Command is also set the resulting invocation is
+                                        append(Command, Args...).  When only Args is set it overrides CMD while
+                                        preserving the image's ENTRYPOINT.
+
+                                        If neither Command nor Args is set, the image's own ENTRYPOINT and CMD
+                                        are used unchanged.
+                                      items:
+                                        type: string
+                                      type: array
+                                    command:
+                                      description: |-
+                                        Entrypoint array to run in the container image, overriding the image's
+                                        ENTRYPOINT. Each element is a separate token, not a shell command — to run a
+                                        shell command use: ["sh", "-c", "my command"].
+
+                                        If not provided, the container image's own ENTRYPOINT is used.
+                                      items:
+                                        type: string
+                                      type: array
                                     env:
                                       description: |-
                                         List of environment variables to set in the container.
@@ -385,8 +407,9 @@ spec:
                                           variable present in a Container.
                                         properties:
                                           name:
-                                            description: Name of the environment variable.
-                                              Must be a C_IDENTIFIER.
+                                            description: |-
+                                              Name of the environment variable.
+                                              May consist of any printable ASCII characters except '='.
                                             type: string
                                           value:
                                             description: |-
@@ -446,6 +469,43 @@ spec:
                                                     type: string
                                                 required:
                                                 - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                description: |-
+                                                  FileKeyRef selects a key of the env file.
+                                                  Requires the EnvFiles feature gate to be enabled.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    description: |-
+                                                      Specify whether the file or its key must be defined. If the file or key
+                                                      does not exist, then the env var is not published.
+                                                      If optional is set to true and the specified key does not exist,
+                                                      the environment variable will not be set in the Pod's containers.
+
+                                                      If optional is set to false and the specified key does not exist,
+                                                      an error will be returned during Pod creation.
+                                                    type: boolean
+                                                  path:
+                                                    description: |-
+                                                      The path within the volume from which to select the file.
+                                                      Must be relative and may not contain the '..' path or start with '..'.
+                                                    type: string
+                                                  volumeName:
+                                                    description: The name of the volume
+                                                      mount containing the env file.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resourceFieldRef:
@@ -1027,8 +1087,9 @@ spec:
                   type: object
                 type: array
               currentReplicas:
-                description: The number of instances which have the latest workload
-                  settings applied.
+                description: |-
+                  The number of instances which have the latest workload settings applied
+                  and are programmed (a subset of UpdatedReplicas that are ready to serve).
                 format: int32
                 type: integer
               desiredReplicas:
@@ -1049,6 +1110,13 @@ spec:
                 - name
                 - namespace
                 type: object
+              observedGeneration:
+                description: |-
+                  The most recent generation observed by the deployment controller. When
+                  this matches metadata.generation, the controller has reconciled the
+                  latest spec (e.g. a restart request).
+                format: int64
+                type: integer
               readyReplicas:
                 description: The number of instances which are ready.
                 format: int32
@@ -1057,11 +1125,20 @@ spec:
                 description: The number of instances created
                 format: int32
                 type: integer
+              updatedReplicas:
+                description: |-
+                  The number of instances updated to the latest template revision, i.e.
+                  whose observed template hash matches the desired template, regardless of
+                  readiness. Lags Replicas during a rolling update or restart, then catches
+                  back up — making an in-progress roll observable.
+                format: int32
+                type: integer
             required:
             - currentReplicas
             - desiredReplicas
             - readyReplicas
             - replicas
+            - updatedReplicas
             type: object
         type: object
     served: true

--- a/config/base/crd/bases/compute.datumapis.com_workloads.yaml
+++ b/config/base/crd/bases/compute.datumapis.com_workloads.yaml
@@ -37,7 +37,7 @@ spec:
     - jsonPath: .status.desiredReplicas
       name: Desired
       type: string
-    - jsonPath: .status.currentReplicas
+    - jsonPath: .status.updatedReplicas
       name: Up-to-date
       type: string
     name: v1alpha
@@ -385,6 +385,28 @@ spec:
                                   sandbox.
                                 items:
                                   properties:
+                                    args:
+                                      description: |-
+                                        Arguments to the entrypoint, overriding the image's CMD. Combined with
+                                        Command: when Command is also set the resulting invocation is
+                                        append(Command, Args...).  When only Args is set it overrides CMD while
+                                        preserving the image's ENTRYPOINT.
+
+                                        If neither Command nor Args is set, the image's own ENTRYPOINT and CMD
+                                        are used unchanged.
+                                      items:
+                                        type: string
+                                      type: array
+                                    command:
+                                      description: |-
+                                        Entrypoint array to run in the container image, overriding the image's
+                                        ENTRYPOINT. Each element is a separate token, not a shell command — to run a
+                                        shell command use: ["sh", "-c", "my command"].
+
+                                        If not provided, the container image's own ENTRYPOINT is used.
+                                      items:
+                                        type: string
+                                      type: array
                                     env:
                                       description: |-
                                         List of environment variables to set in the container.
@@ -395,8 +417,9 @@ spec:
                                           variable present in a Container.
                                         properties:
                                           name:
-                                            description: Name of the environment variable.
-                                              Must be a C_IDENTIFIER.
+                                            description: |-
+                                              Name of the environment variable.
+                                              May consist of any printable ASCII characters except '='.
                                             type: string
                                           value:
                                             description: |-
@@ -456,6 +479,43 @@ spec:
                                                     type: string
                                                 required:
                                                 - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                description: |-
+                                                  FileKeyRef selects a key of the env file.
+                                                  Requires the EnvFiles feature gate to be enabled.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    description: |-
+                                                      Specify whether the file or its key must be defined. If the file or key
+                                                      does not exist, then the env var is not published.
+                                                      If optional is set to true and the specified key does not exist,
+                                                      the environment variable will not be set in the Pod's containers.
+
+                                                      If optional is set to false and the specified key does not exist,
+                                                      an error will be returned during Pod creation.
+                                                    type: boolean
+                                                  path:
+                                                    description: |-
+                                                      The path within the volume from which to select the file.
+                                                      Must be relative and may not contain the '..' path or start with '..'.
+                                                    type: string
+                                                  volumeName:
+                                                    description: The name of the volume
+                                                      mount containing the env file.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resourceFieldRef:
@@ -1021,8 +1081,9 @@ spec:
                   type: object
                 type: array
               currentReplicas:
-                description: The number of instances which have the latest workload
-                  settings applied.
+                description: |-
+                  The number of instances which have the latest workload settings applied
+                  and are programmed (a subset of UpdatedReplicas that are ready to serve).
                 format: int32
                 type: integer
               deployments:
@@ -1307,6 +1368,10 @@ spec:
                     - name
                     x-kubernetes-list-type: map
                 type: object
+              observedGeneration:
+                description: The most recent generation observed by the workload controller.
+                format: int64
+                type: integer
               placements:
                 description: The current status of placemetns in a workload.
                 items:
@@ -1372,8 +1437,9 @@ spec:
                         type: object
                       type: array
                     currentReplicas:
-                      description: The number of instances which have the latest workload
-                        settings applied.
+                      description: |-
+                        The number of instances which have the latest workload settings applied
+                        and are programmed (a subset of UpdatedReplicas that are ready to serve).
                       format: int32
                       type: integer
                     desiredReplicas:
@@ -1391,12 +1457,19 @@ spec:
                       description: The number of instances that currently exist
                       format: int32
                       type: integer
+                    updatedReplicas:
+                      description: |-
+                        The number of instances updated to the latest template revision, regardless
+                        of readiness. Lags Replicas during a rolling update or restart.
+                      format: int32
+                      type: integer
                   required:
                   - currentReplicas
                   - desiredReplicas
                   - name
                   - readyReplicas
                   - replicas
+                  - updatedReplicas
                   type: object
                 type: array
               readyReplicas:
@@ -1407,12 +1480,21 @@ spec:
                 description: The number of instances that currently exist
                 format: int32
                 type: integer
+              updatedReplicas:
+                description: |-
+                  The number of instances updated to the latest template revision (their
+                  observed template hash matches the desired template), regardless of
+                  readiness. Lags Replicas during a rolling update or restart, then catches
+                  back up — making an in-progress roll observable.
+                format: int32
+                type: integer
             required:
             - currentReplicas
             - deployments
             - desiredReplicas
             - readyReplicas
             - replicas
+            - updatedReplicas
             type: object
         required:
         - spec

--- a/internal/controller/instance_controller.go
+++ b/internal/controller/instance_controller.go
@@ -304,7 +304,7 @@ func (r *InstanceReconciler) reconcileInstanceReadyCondition(
 			ObservedGeneration: instance.Generation,
 		})
 		changed = apimeta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:               computev1alpha.InstanceRunning,
+			Type:               computev1alpha.InstanceAvailable,
 			Status:             metav1.ConditionFalse,
 			Reason:             computev1alpha.InstanceProgrammedReasonPendingQuota,
 			Message:            msg,
@@ -375,7 +375,7 @@ func (r *InstanceReconciler) reconcileInstanceReadyCondition(
 
 	logger.Info("instance is programmed", "instance", instance.Name)
 
-	runningCondition := apimeta.FindStatusCondition(instance.Status.Conditions, computev1alpha.InstanceRunning)
+	runningCondition := apimeta.FindStatusCondition(instance.Status.Conditions, computev1alpha.InstanceAvailable)
 	if runningCondition == nil || runningCondition.Status != metav1.ConditionTrue {
 		logger.Info("instance is not running", "instance", instance.Name)
 
@@ -393,7 +393,7 @@ func (r *InstanceReconciler) reconcileInstanceReadyCondition(
 	}
 
 	readyCondition.Status = metav1.ConditionTrue
-	readyCondition.Reason = computev1alpha.InstanceReadyReasonRunning
+	readyCondition.Reason = computev1alpha.InstanceReadyReasonAvailable
 	readyCondition.Message = "Instance is ready"
 
 	return apimeta.SetStatusCondition(&instance.Status.Conditions, *readyCondition), nil

--- a/internal/controller/instance_controller_test.go
+++ b/internal/controller/instance_controller_test.go
@@ -203,7 +203,7 @@ func TestReconcileInstanceReadyCondition(t *testing.T) {
 							Message: "Instance has been programmed",
 						},
 						{
-							Type:    computev1alpha.InstanceRunning,
+							Type:    computev1alpha.InstanceAvailable,
 							Status:  metav1.ConditionFalse,
 							Reason:  "TestReason",
 							Message: "Test message",
@@ -237,9 +237,9 @@ func TestReconcileInstanceReadyCondition(t *testing.T) {
 							Message: "Instance has been programmed",
 						},
 						{
-							Type:    computev1alpha.InstanceRunning,
+							Type:    computev1alpha.InstanceAvailable,
 							Status:  metav1.ConditionTrue,
-							Reason:  computev1alpha.InstanceRunningReasonRunning,
+							Reason:  computev1alpha.InstanceAvailableReasonAvailable,
 							Message: "Instance is running",
 						},
 					},
@@ -249,7 +249,7 @@ func TestReconcileInstanceReadyCondition(t *testing.T) {
 			expectedCondition: &metav1.Condition{
 				Type:               computev1alpha.InstanceReady,
 				Status:             metav1.ConditionTrue,
-				Reason:             computev1alpha.InstanceReadyReasonRunning,
+				Reason:             computev1alpha.InstanceReadyReasonAvailable,
 				Message:            "Instance is ready",
 				ObservedGeneration: 1,
 			},
@@ -267,7 +267,7 @@ func TestReconcileInstanceReadyCondition(t *testing.T) {
 						{
 							Type:               computev1alpha.InstanceReady,
 							Status:             metav1.ConditionTrue,
-							Reason:             computev1alpha.InstanceReadyReasonRunning,
+							Reason:             computev1alpha.InstanceReadyReasonAvailable,
 							Message:            "Instance is ready",
 							ObservedGeneration: 1,
 							LastTransitionTime: metav1.Now(),
@@ -279,9 +279,9 @@ func TestReconcileInstanceReadyCondition(t *testing.T) {
 							Message: "Instance has been programmed",
 						},
 						{
-							Type:    computev1alpha.InstanceRunning,
+							Type:    computev1alpha.InstanceAvailable,
 							Status:  metav1.ConditionTrue,
-							Reason:  computev1alpha.InstanceRunningReasonRunning,
+							Reason:  computev1alpha.InstanceAvailableReasonAvailable,
 							Message: "Instance is running",
 						},
 					},
@@ -291,7 +291,7 @@ func TestReconcileInstanceReadyCondition(t *testing.T) {
 			expectedCondition: &metav1.Condition{
 				Type:               computev1alpha.InstanceReady,
 				Status:             metav1.ConditionTrue,
-				Reason:             computev1alpha.InstanceReadyReasonRunning,
+				Reason:             computev1alpha.InstanceReadyReasonAvailable,
 				Message:            "Instance is ready",
 				ObservedGeneration: 1,
 			},
@@ -364,9 +364,9 @@ func TestReconcileInstanceReadyConditionWithQuota(t *testing.T) {
 							LastTransitionTime: metav1.Now(),
 						},
 						{
-							Type:               computev1alpha.InstanceRunning,
+							Type:               computev1alpha.InstanceAvailable,
 							Status:             metav1.ConditionTrue,
-							Reason:             computev1alpha.InstanceRunningReasonRunning,
+							Reason:             computev1alpha.InstanceAvailableReasonAvailable,
 							Message:            "Instance is running",
 							LastTransitionTime: metav1.Now(),
 						},
@@ -406,9 +406,9 @@ func TestReconcileInstanceReadyConditionWithQuota(t *testing.T) {
 							LastTransitionTime: metav1.Now(),
 						},
 						{
-							Type:               computev1alpha.InstanceRunning,
+							Type:               computev1alpha.InstanceAvailable,
 							Status:             metav1.ConditionTrue,
-							Reason:             computev1alpha.InstanceRunningReasonRunning,
+							Reason:             computev1alpha.InstanceAvailableReasonAvailable,
 							Message:            "Instance is running",
 							LastTransitionTime: metav1.Now(),
 						},
@@ -419,7 +419,7 @@ func TestReconcileInstanceReadyConditionWithQuota(t *testing.T) {
 			expectedCondition: &metav1.Condition{
 				Type:    computev1alpha.InstanceReady,
 				Status:  metav1.ConditionTrue,
-				Reason:  computev1alpha.InstanceReadyReasonRunning,
+				Reason:  computev1alpha.InstanceReadyReasonAvailable,
 				Message: "Instance is ready",
 			},
 		},
@@ -664,7 +664,7 @@ func TestReconcileQuota(t *testing.T) {
 		assert.Equal(t, metav1.ConditionFalse, programmedCond.Status)
 		assert.Equal(t, computev1alpha.InstanceProgrammedReasonPendingQuota, programmedCond.Reason)
 
-		runningCond := apimeta.FindStatusCondition(updated.Status.Conditions, computev1alpha.InstanceRunning)
+		runningCond := apimeta.FindStatusCondition(updated.Status.Conditions, computev1alpha.InstanceAvailable)
 		require.NotNil(t, runningCond)
 		assert.Equal(t, metav1.ConditionFalse, runningCond.Status)
 		assert.Equal(t, computev1alpha.InstanceProgrammedReasonPendingQuota, runningCond.Reason)


### PR DESCRIPTION
## Why `Available`, not `Running`

We're renaming the Instance readiness condition from `Running` to `Available` — and the reason is the user's mental model, not a cosmetic preference.

`Running` implies a process is actively executing *right now*. That's the wrong guarantee for a **scale-to-zero Instance that's woken on activity**: such an Instance may be scaled to zero with nothing executing, yet it is still fully **available** — it will accept a request and wake on demand. Reporting that Instance as not-`Running` would be alarming and simply wrong; reporting it as `Available` states the guarantee users actually care about — *the workload is ready to serve* — independent of whether anything is running at this instant.

So `Available` decouples readiness from runtime state. A dormant, scale-to-zero Instance and a warm, actively-serving one are both `Available`; the distinction between "asleep" and "executing" belongs in reasons/metrics, not in the top-level readiness signal. It also matches how the rest of the platform expresses "ready to use," keeping the signal consistent across resources.

## What

- The Instance readiness condition becomes **`Available`** instead of `Running` (the existing controller is updated to match, so nothing breaks today).
- Status gets more informative: an Instance that isn't ready can now say **why** — still provisioning, image couldn't be pulled, the app is crashing, or the config was rejected — and Workloads/WorkloadDeployments surface rollout progress.
- The published CRDs are regenerated to match.

This is an API-and-contract change only — no new controller behavior — and it builds and passes tests against `main` on its own.

## ⚠️ Breaking

The Instance `Running` condition is renamed to `Available`. Anything reading the `Running` condition (its type or reasons) must move to `Available`.

## Stack

Base of the federation foundation: `main ← this ← #107 ← …`. Extracted from #107 so the breaking rename — and the rationale above — reviews on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
