### PR TITLE
feat(quota): add display names and descriptions to compute quota limits

### DIFF
--- a/config/components/service-catalog/service-configuration.yaml
+++ b/config/components/service-catalog/service-configuration.yaml
@@ -62,6 +62,8 @@ spec:
   quota:
     limits:
     - name: compute-workloads
+      displayName: Workloads
+      description: Maximum number of workloads that can be created within a project.
       metric: compute.datumapis.com/workloads
       consumerType:
         apiGroup: resourcemanager.miloapis.com
@@ -69,6 +71,8 @@ spec:
       unit: instance
       defaultLimit: 1000
     - name: compute-instances
+      displayName: Instances
+      description: Maximum number of compute instances that can run within a project.
       metric: compute.datumapis.com/instances
       consumerType:
         apiGroup: resourcemanager.miloapis.com
@@ -76,6 +80,8 @@ spec:
       unit: instance
       defaultLimit: 10
     - name: compute-vcpus
+      displayName: vCPUs
+      description: Maximum total vCPUs (in millicores) allocatable to instances within a project.
       metric: compute.datumapis.com/vcpus
       consumerType:
         apiGroup: resourcemanager.miloapis.com
@@ -83,6 +89,8 @@ spec:
       unit: millicore
       defaultLimit: 40000
     - name: compute-memory
+      displayName: Memory
+      description: Maximum total memory (in MiB) allocatable to instances within a project.
       metric: compute.datumapis.com/memory
       consumerType:
         apiGroup: resourcemanager.miloapis.com


### PR DESCRIPTION
## What
Populate `displayName` + `description` on each `spec.quota.limits[]` entry in the compute `ServiceConfiguration`:

| limit | displayName |
|---|---|
| compute-workloads | Workloads |
| compute-instances | Instances |
| compute-vcpus | vCPUs |
| compute-memory | Memory |

## Why
The service-catalog quota fan-out generates a `ResourceRegistration` per limit. With these fields populated it stamps `kubernetes.io/display-name` / `kubernetes.io/description`, so portals (cloud-portal Quotas) render readable names instead of raw `compute.datumapis.com/*` metric keys.

## ⚠️ Depends on
**milo-os/service-catalog#41** — adds `DisplayName`/`Description` to `QuotaLimitSpec`. This PR is **draft** until that lands and the `ServiceConfiguration` CRD with the new schema is deployed; applying before then would be rejected as unknown fields.

## Related
- cloud-portal interim mapping: datum-cloud/cloud-portal#1310 (its interim resourceType→name map can be removed once this is live).