### PR TITLE
docs: cross-link federation docs with edge instance-provisioning architecture

### DIFF
--- a/docs/compute/development/rfcs/workloads/README.md
+++ b/docs/compute/development/rfcs/workloads/README.md
@@ -653,6 +653,8 @@ sequenceDiagram
   WorkloadDeploymentScheduler-->>Controller: Return (no requeue)
 ```
 
+Once a `WorkloadDeployment` is assigned a location, the compute operator at that location creates the individual Instances. How an edge location turns these Instances into running unikernels — host assignment, networking, and boot via Kraftlet — is documented in [Instance Provisioning via Kraftlet](https://github.com/datum-cloud/unikraft-provider/blob/main/docs/enhancements/instance-provisioning.md) in the unikraft-provider repository.
+
 ## Production Readiness Review Questionnaire
 
 <!--

--- a/docs/enhancements/federated-deployment-scheduling.md
+++ b/docs/enhancements/federated-deployment-scheduling.md
@@ -165,6 +165,8 @@ sequenceDiagram
     CPC->>Project: write Workload.status
 ```
 
+The POP cell steps above are summarized from the federation perspective. How an edge location turns these Instances into running unikernels — Kraftlet picking up each Instance, wiring up host networking, booting the unikernel, and reporting status back — is documented in [Instance Provisioning via Kraftlet](https://github.com/datum-cloud/unikraft-provider/blob/main/docs/enhancements/instance-provisioning.md).
+
 ### Deletion Path
 
 ```mermaid
@@ -241,6 +243,8 @@ A new controller in the Control Plane Cell:
 - Manages `network` scheduling gate removal once NSO signals networks are ready.
 - Updates local `WorkloadDeployment.status` with aggregate replica counts (Karmada aggregates this back natively).
 - **Remove**: `WorkloadDeployment.status.location` (location is now implicit in `spec.cityCode`).
+
+The edge-side path from a created `Instance` to a booted unikernel — host assignment by the Unikraft Provider, networking, and boot via Kraftlet — is covered in [Instance Provisioning via Kraftlet](https://github.com/datum-cloud/unikraft-provider/blob/main/docs/enhancements/instance-provisioning.md).
 
 ### `InstanceReconciler`
 


### PR DESCRIPTION
## What this gives readers

Someone reading the compute architecture docs today can follow a Workload all the way to "the POP cell creates Instances" — and then the trail goes cold. The edge half of the story (how a created Instance becomes a booted unikernel: host assignment, networking, Kraftlet) lives in the unikraft-provider repo, with no pointer from here. This PR adds cross-links at the exact spots where the federation docs hand off to the edge, so readers can continue into [Instance Provisioning via Kraftlet](https://github.com/datum-cloud/unikraft-provider/blob/main/docs/enhancements/instance-provisioning.md) without knowing in advance which repo holds it.

## Changes

- `docs/enhancements/federated-deployment-scheduling.md` — two prose links: one after the Creation Path sequence diagram (where the POP cell steps are summarized), one at the end of the `WorkloadDeploymentReconciler` section (where Instance materialization is described).
- `docs/compute/development/rfcs/workloads/README.md` — one link at the end of the Control Loops section, after the Workload Scheduler diagram, covering what happens once a `WorkloadDeployment` is assigned a location.

No generated API references (`docs/api/`) were touched.

## Merge ordering

The linked doc lands with datum-cloud/unikraft-provider#9 — merge this PR **after** that one, since the links 404 until it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)