### PR TITLE
test: migrate workload-api-acceptance from infra (WIP)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,26 @@ test-e2e: manifests generate fmt vet ## Run the e2e tests. Expected an isolated 
 	# }
 	# go test ./test/e2e/ -v -ginkgo.v
 
+# WIP: proposed chainsaw-based API-contract e2e harness. Migrated from
+# datum-cloud/infra#3006. Runs live-env chainsaw contract tests against a local
+# kind cluster. Compute-team to confirm chainsaw vs. extending the Go e2e suite.
+KIND_CLUSTER ?= compute-e2e
+TMPDIR ?= /tmp
+
+.PHONY: test-chainsaw
+test-chainsaw: chainsaw ## WIP: run chainsaw API-contract e2e tests against a kind cluster.
+	@command -v kind >/dev/null 2>&1 || { \
+		echo "Kind is not installed. Please install Kind manually."; \
+		exit 1; \
+	}
+	@kind get clusters | grep -q '$(KIND_CLUSTER)' || { \
+		echo "No '$(KIND_CLUSTER)' kind cluster found. Create it before running chainsaw e2e."; \
+		exit 1; \
+	}
+	$(KIND) get kubeconfig --name $(KIND_CLUSTER) > $(TMPDIR)/.kind-$(KIND_CLUSTER).yaml
+	$(CHAINSAW) test ./test/e2e \
+		--cluster $(KIND_CLUSTER)=$(TMPDIR)/.kind-$(KIND_CLUSTER).yaml
+
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
@@ -171,6 +191,8 @@ DEFAULTER_GEN ?= $(LOCALBIN)/defaulter-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 CRDOC ?= $(LOCALBIN)/crdoc
+KIND ?= $(LOCALBIN)/kind
+CHAINSAW ?= $(LOCALBIN)/chainsaw
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.5.0
@@ -181,6 +203,12 @@ GOLANGCI_LINT_VERSION ?= v2.12.2
 
 # renovate: datasource=go depName=fybrik.io/crdoc
 CRDOC_VERSION ?= v0.6.4
+
+# renovate: datasource=go depName=sigs.k8s.io/kind
+KIND_VERSION ?= v0.27.0
+
+# renovate: datasource=go depName=github.com/kyverno/chainsaw
+CHAINSAW_VERSION ?= v0.2.15
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -210,6 +238,16 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 .PHONY: crdoc
 crdoc: ## Download crdoc locally if necessary.
 	$(call go-install-tool,$(CRDOC),fybrik.io/crdoc,$(CRDOC_VERSION))
+
+.PHONY: kind
+kind: $(KIND) ## Download kind locally if necessary.
+$(KIND): $(LOCALBIN)
+	$(call go-install-tool,$(KIND),sigs.k8s.io/kind,$(KIND_VERSION))
+
+.PHONY: chainsaw
+chainsaw: $(CHAINSAW) ## Download chainsaw locally if necessary.
+$(CHAINSAW): $(LOCALBIN)
+	$(call go-install-tool,$(CHAINSAW),github.com/kyverno/chainsaw,$(CHAINSAW_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/test/e2e/workload-api-acceptance/chainsaw-test.yaml
+++ b/test/e2e/workload-api-acceptance/chainsaw-test.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: workload-api-acceptance
+spec:
+  cluster: compute-e2e
+  steps:
+    - name: Apply networking fixtures
+      try:
+        - apply:
+            timeout: 1m
+            file: location.yaml
+        - apply:
+            timeout: 1m
+            file: network.yaml
+        - assert:
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: Network
+              metadata:
+                name: e2e-acceptance-network
+
+    - name: Apply Workload and assert acceptance
+      try:
+        - apply:
+            timeout: 1m
+            file: workload.yaml
+        - assert:
+            resource:
+              apiVersion: compute.datumapis.com/v1alpha
+              kind: Workload
+              metadata:
+                name: e2e-acceptance-workload

--- a/test/e2e/workload-api-acceptance/location.yaml
+++ b/test/e2e/workload-api-acceptance/location.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.datumapis.com/v1alpha
+kind: Location
+metadata:
+  name: us-central1-a
+  labels:
+    topology.datum.net/city-code: ORD
+spec:
+  provider:
+    gcp:
+      projectId: datum-cloud-staging
+      region: us-central1
+      zone: us-central1-a

--- a/test/e2e/workload-api-acceptance/network.yaml
+++ b/test/e2e/workload-api-acceptance/network.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.datumapis.com/v1alpha
+kind: Network
+metadata:
+  name: e2e-acceptance-network
+  namespace: default
+spec:
+  ipam:
+    mode: Auto

--- a/test/e2e/workload-api-acceptance/workload.yaml
+++ b/test/e2e/workload-api-acceptance/workload.yaml
@@ -1,0 +1,34 @@
+apiVersion: compute.datumapis.com/v1alpha
+kind: Workload
+metadata:
+  name: e2e-acceptance-workload
+  namespace: default
+spec:
+  template:
+    spec:
+      runtime:
+        resources:
+          instanceType: datumcloud/d1-standard-2
+        sandbox:
+          containers:
+            - name: httpbin
+              image: kennethreitz/httpbin
+              ports:
+                - name: http
+                  port: 80
+      networkInterfaces:
+        - network:
+            name: e2e-acceptance-network
+          networkPolicy:
+            ingress:
+              - ports:
+                  - port: 80
+                from:
+                  - ipBlock:
+                      cidr: 0.0.0.0/0
+  placements:
+    - name: central
+      cityCodes:
+        - ORD
+      scaleSettings:
+        minReplicas: 1


### PR DESCRIPTION
> **WIP / DRAFT.** Not intended to be green CI yet. See "Known-uncertain" below.

## What

Migrates the `workload-api-acceptance` Chainsaw test out of `datum-cloud/infra`
into this repo (the owner of the `compute.datumapis.com` Workload contract), and
**introduces a minimal Chainsaw harness to compute**, which currently has none.

- New test: `test/e2e/workload-api-acceptance/` (chainsaw test plus `location.yaml`,
  `network.yaml`, `workload.yaml` fixtures copied from infra).
- Applies a `Workload` (plus networking `Location` and `Network` fixtures) and asserts
  the control plane accepts and stores the `Workload`. API schema and admission
  only, no wait for VM provisioning.
- Makefile: adds `kind` and `chainsaw` tool vars, versions, and install targets, plus a
  `make test-chainsaw` target that runs `chainsaw test ./test/e2e` against a local
  kind cluster (mirrors `datum-cloud/network-services-operator`).

## Why

`datum-cloud/infra#3006` consolidates infra's live-env Chainsaw suite into one
"construct" group and evacuates single-service API-contract tests to their owning
repos, to be run against the local kind harness pre-merge. This test validates a
`compute.datumapis.com` contract owned by this repo.

Related: `datum-cloud/infra#3006`, `datum-cloud/infra#3005`.

## Adaptations from the infra original

- Removed the `datumctl auth update-kubeconfig` setup step and the
  `clusters:` / `cluster: project` blocks referencing `./test-kubeconfig`.
- Target a local kind cluster via `spec.cluster: compute-e2e`, mirroring NSO.
- Removed `spec.skip: true`.

## Introduces Chainsaw to compute: decision to confirm

Compute has **no Chainsaw harness today**; its only e2e is the kubebuilder Go
suite (`test/e2e/e2e_test.go`, `make test-e2e`, currently a stub). This PR adds a
**proposed, WIP** Chainsaw harness. The compute team should decide:

- **(A)** adopt Chainsaw for API-contract e2e (this PR), or
- **(B)** re-express these contract assertions inside the existing Go/kubebuilder
  e2e and drop the Chainsaw wiring.

The harness wiring here is deliberately minimal and marked WIP so the migration is
reviewable regardless of which path is chosen.

## Known-uncertain

- **Networking CRDs and controller are not in this repo.** The fixtures use
  `networking.datumapis.com` (`Location`, `Network`). A compute-only local kind
  env will not serve these unless NSO CRDs are installed first. The harness does
  not install them yet, so this needs a decision: install NSO CRDs in the e2e
  bring-up, or drop the networking fixtures.
- **The Workload validating webhook lists `LocationBinding`
  (networking.datumapis.com) during `ValidateCreate`** and derives valid city
  codes from `LocationBinding.Spec.Topology["topology.datum.net/city-code"]`. So:
  - the webhook needs the networking CRDs present, and
  - `cityCodes: [ORD]` requires a matching **`LocationBinding`** (the infra
    fixture applies a `Location`, not a `LocationBinding`) or admission fails
    `Invalid`. This is the same class of failure that had the original test
    `skip: true` (infra #2733). Resolving it (add a `LocationBinding` fixture,
    or run the webhook with location validation relaxed) is left for the
    compute-team review.
- **`spec.cluster` name** is assumed to be `compute-e2e`. Compute's current CI
  creates a default-named kind cluster (`kind create cluster`, which yields `kind`). The
  Makefile exposes `KIND_CLUSTER ?= compute-e2e`; the e2e bring-up should create a
  cluster of that name, or override the var.
- **Kind and Chainsaw versions** pinned to match NSO (`kind v0.27.0`,
  `chainsaw v0.2.15`); adjust to compute's preference.
