### PR TITLE
test: migrate workload-derives-deployment from infra (WIP)

### DIFF
--- a/test/e2e/workload-derives-deployment/chainsaw-test.yaml
+++ b/test/e2e/workload-derives-deployment/chainsaw-test.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: workload-derives-deployment
+spec:
+  cluster: compute-e2e
+  steps:
+    - name: Apply Workload and fixtures
+      try:
+        - apply:
+            timeout: 1m
+            file: location.yaml
+        - apply:
+            timeout: 1m
+            file: network.yaml
+        - apply:
+            timeout: 1m
+            file: workload.yaml
+        - assert:
+            resource:
+              apiVersion: compute.datumapis.com/v1alpha
+              kind: Workload
+              metadata:
+                name: e2e-derived-workload
+
+    - name: Assert WorkloadDeployment is derived per placement
+      try:
+        - wait:
+            apiVersion: compute.datumapis.com/v1alpha
+            kind: WorkloadDeployment
+            name: e2e-derived-workload-central
+            timeout: 3m
+            for:
+              condition:
+                name: Progressing
+                value: 'true'
+        - assert:
+            resource:
+              apiVersion: compute.datumapis.com/v1alpha
+              kind: WorkloadDeployment
+              metadata:
+                name: e2e-derived-workload-central

--- a/test/e2e/workload-derives-deployment/location.yaml
+++ b/test/e2e/workload-derives-deployment/location.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.datumapis.com/v1alpha
+kind: Location
+metadata:
+  name: us-central1-a
+  labels:
+    topology.datum.net/city-code: ORD
+spec:
+  provider:
+    gcp:
+      projectId: datum-cloud-staging
+      region: us-central1
+      zone: us-central1-a

--- a/test/e2e/workload-derives-deployment/network.yaml
+++ b/test/e2e/workload-derives-deployment/network.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.datumapis.com/v1alpha
+kind: Network
+metadata:
+  name: e2e-derived-network
+  namespace: default
+spec:
+  ipam:
+    mode: Auto

--- a/test/e2e/workload-derives-deployment/workload.yaml
+++ b/test/e2e/workload-derives-deployment/workload.yaml
@@ -1,0 +1,34 @@
+apiVersion: compute.datumapis.com/v1alpha
+kind: Workload
+metadata:
+  name: e2e-derived-workload
+  namespace: default
+spec:
+  template:
+    spec:
+      runtime:
+        resources:
+          instanceType: datumcloud/d1-standard-2
+        sandbox:
+          containers:
+            - name: httpbin
+              image: kennethreitz/httpbin
+              ports:
+                - name: http
+                  port: 80
+      networkInterfaces:
+        - network:
+            name: e2e-derived-network
+          networkPolicy:
+            ingress:
+              - ports:
+                  - port: 80
+                from:
+                  - ipBlock:
+                      cidr: 0.0.0.0/0
+  placements:
+    - name: central
+      cityCodes:
+        - ORD
+      scaleSettings:
+        minReplicas: 1


### PR DESCRIPTION
> **WIP / DRAFT.** Not intended to be green CI yet. See "Known-uncertain" below.
> **Depends on #159** (the `workload-api-acceptance` migration), which introduces
> the Chainsaw harness (`kind` and `chainsaw` Makefile tooling and the
> `make test-chainsaw` target). This PR adds test files only.

## What

Migrates the `workload-derives-deployment` Chainsaw test out of
`datum-cloud/infra` into this repo (the owner of the `compute.datumapis.com`
Workload and WorkloadDeployment contract).

- New test: `test/e2e/workload-derives-deployment/` (chainsaw test plus `location.yaml`,
  `network.yaml`, `workload.yaml` fixtures copied from infra).
- Applies a `Workload`, asserts the control plane accepts it, waits for the
  derived `WorkloadDeployment` (`e2e-derived-workload-central`) to reach
  `Progressing=true`, and asserts it. Control-plane derivation only, no wait for
  VMs to become `Available`.

## Why

`datum-cloud/infra#3006` consolidates infra's live-env Chainsaw suite into one
"construct" group and evacuates single-service API-contract tests to their owning
repos, to be run against the local kind harness pre-merge. This test validates a
`compute.datumapis.com` contract owned by this repo.

Related: `datum-cloud/infra#3006`, `datum-cloud/infra#3005`.

## Adaptations from the infra original

- Removed the `datumctl auth update-kubeconfig` setup step and the
  `clusters:` / `cluster: project` blocks referencing `./test-kubeconfig`.
- Target a local kind cluster via `spec.cluster: compute-e2e`, mirroring NSO.
- Removed `spec.skip: true`.

## Introduces Chainsaw to compute: decision to confirm

Compute has **no Chainsaw harness today**, only the kubebuilder Go e2e stub.
This PR relies on the proposed Chainsaw harness added in #159. The compute team
should decide between:

- **(A)** adopting Chainsaw for API-contract e2e (this plus #159), or
- **(B)** re-expressing these assertions inside the existing Go/kubebuilder e2e.

## Known-uncertain

- **Networking CRDs and controller are not in this repo.** Fixtures use
  `networking.datumapis.com` (`Location`, `Network`); a compute-only kind env
  will not serve them unless NSO CRDs are installed in the e2e bring-up.
- **Workload derivation depends on the networking integration.** The Workload
  validating webhook lists `LocationBinding` and validates `cityCodes: [ORD]`
  against `LocationBinding.Spec.Topology["topology.datum.net/city-code"]`, so a
  matching `LocationBinding` (not just the `Location` in the fixture) is required
  or `ValidateCreate` fails `Invalid`. Reaching `WorkloadDeployment
  Progressing=true` further depends on the controller's networking behavior:
  with `NetworkingEnabled=false` the Network scheduling gate is cleared and
  `Progressing` can be reached without networking; with it enabled, a resolvable
  Location and Network are needed. The correct harness config (install NSO CRDs plus a
  `LocationBinding` fixture, versus running compute with `NetworkingEnabled=false`) is a
  compute-team decision. This is the same class of failure that had the original
  test `skip: true` (infra #2733).
- **`spec.cluster` name** assumed `compute-e2e` (see #159; `KIND_CLUSTER` var).
- **3m wait timeout** carried over from the infra original; may need tuning for
  the local harness.
