### PR TITLE
feat(federation): add minimal edge-scoped ClusterRole for cell write-back

### DIFF
--- a/config/base/downstream-rbac/edge-federation-rbac.yaml
+++ b/config/base/downstream-rbac/edge-federation-rbac.yaml
@@ -1,0 +1,49 @@
+# Least-privilege federation access for the edge (cell) compute-manager on the
+# Karmada control plane. This is a dedicated ClusterRole — deliberately NOT the
+# broad compute-manager role above (which the management plane needs) — scoped to
+# what the cell InstanceReconciler's FederationClient does on the hub in Finalize
+# + writeBackToUpstream (internal/controller/instance_controller.go):
+#
+#   * Get the federation Namespace to resolve write-back identity labels.
+#   * Get / Create / Update / Delete this cell's own write-back Instance.
+#   * Update the write-back Instance's status.
+#
+# The cell uses a direct (non-caching) federation client, so no list/watch is
+# required, and it never touches configmaps/secrets, workloaddeployments, or
+# propagationpolicies on the hub. (The functional minimum is get/create/update/
+# delete on instances + update on instances/status; the extra patch/status-get
+# verbs mirror the role first shipped in infra#3202 so this relocation is a
+# faithful, thrash-free move — patch is a partial-update peer of update.)
+#
+# Bound to the dedicated edge identity by CN specifically — the client cert the
+# infra deployment control plane issues (CN
+# system:compute-edge-federation@compute.datumapis.com) — not to the broad
+# compute.datumapis.com group, so only this identity receives the edge role.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: compute-edge-federation
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]
+  - apiGroups: ["compute.datumapis.com"]
+    resources: ["instances"]
+    verbs: ["get", "create", "update", "patch", "delete"]
+  - apiGroups: ["compute.datumapis.com"]
+    resources: ["instances/status"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: compute-edge-federation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: compute-edge-federation
+subjects:
+  - kind: User
+    name: system:compute-edge-federation@compute.datumapis.com
+    apiGroup: rbac.authorization.k8s.io

--- a/config/base/downstream-rbac/kustomization.yaml
+++ b/config/base/downstream-rbac/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
   - rbac.yaml
+  - edge-federation-rbac.yaml


### PR DESCRIPTION
## What

The edge (cell) compute-manager authenticates to the hub Karmada control plane with a **dedicated client-cert identity** (`system:compute-edge-federation@compute.datumapis.com`, issued by the infra deployment control plane) to write Instance status back for its cell. This relocates that identity's **least-privilege** ClusterRole into the compute repo's `config/base/downstream-rbac`, where the rest of the compute federation RBAC lives — rather than the broad `compute-manager` role the management plane uses.

`config/base/downstream-rbac/edge-federation-rbac.yaml`:
- **ClusterRole `compute-edge-federation`** — scoped to exactly what the cell's `InstanceReconciler` FederationClient does on the hub.
- **ClusterRoleBinding** to the identity **by CN specifically** (not the broad `compute.datumapis.com` group), so only this identity receives the edge role.

Ships in the existing `downstream-rbac` kustomization, so it applies to Karmada alongside the management-plane `compute-manager` role.

## Scope, derived from the code

The cell reaches the hub only through `InstanceReconciler.FederationClient`, and only in `Finalize` + `writeBackToUpstream` (`internal/controller/instance_controller.go:1006-1155`). It is a **direct (non-caching)** client (`cmd/main.go:268,291`), and `SetupWithManager`'s watches are all on the local/managed cell clusters — so no list/watch on the hub. Complete hub operation set:

| Resource | Verbs (from code) | Call sites |
|---|---|---|
| `namespaces` | `get` | 1045 |
| `compute.datumapis.com/instances` | `get, create, update, delete` | 1013, 1104 / 1112 / 1142 / 1021 |
| `compute.datumapis.com/instances/status` | `update` | 1116, 1149 |

Nothing else — no configmaps/secrets, no workloaddeployments, no propagationpolicies (those are management-plane concerns in the broad role).

The role as written also carries `patch` on instances and `get,patch` on instances/status. Those are not exercised by the code (the functional minimum is the table above), but they mirror the role first shipped in infra#3202 exactly, so relocating it here is a **faithful, thrash-free move** rather than a competing same-named role. `patch` is a partial-update peer of `update`; happy to shave it (and `status:get`) to the literal minimum as a trivial follow-up once the move settles.

## Related & ordering

- Infra companion PR: datum-cloud/infra#3206 — removes the identical role from the infra karmada post-install (added in infra#3202) and wires `clusters/production/apps/compute-karmada.yaml` so this role reaches the **prod** hub the edge cells federate to.
- The cert that issues `system:compute-edge-federation@compute.datumapis.com` was added in infra#3202 (already merged).
- **Ordering:** merge this PR and let the `compute-kustomize` OCI artifact publish **before** infra#3206 lands, so this role is applied to the hub before infra#3206 removes the post-install copy. Because the two roles are byte-identical, any brief overlap is a no-op rather than a conflict.
- Edge compute enablement: datum-cloud/infra#3021.