### PR TITLE
Mount the quota credential as cert files plus a static kubeconfig

### DIFF
--- a/config/components/quota-credentials/kustomization.yaml
+++ b/config/components/quota-credentials/kustomization.yaml
@@ -1,3 +1,9 @@
+# Mounts the quota credential for compute-manager at /etc/quota-credentials:
+# the Milo client certificate (ca.crt/tls.crt/tls.key) and a static kubeconfig
+# that references those cert files by path, combined into one directory via a
+# projected volume. The cluster environment supplies both sources
+# (compute-edge-milo-client-cert Secret + compute-quota-kubeconfig ConfigMap);
+# they are optional so compute-manager still starts where quota is not wired.
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
@@ -21,6 +27,11 @@ patches:
                     readOnly: true
             volumes:
               - name: quota-credentials
-                secret:
-                  secretName: compute-quota-credentials
-                  optional: true
+                projected:
+                  sources:
+                    - secret:
+                        name: compute-edge-milo-client-cert
+                        optional: true
+                    - configMap:
+                        name: compute-quota-kubeconfig
+                        optional: true


### PR DESCRIPTION
## What this does

Changes the compute-manager quota-credentials volume from a single opaque secret to a projected volume that combines the Milo client certificate with a static kubeconfig ConfigMap, both supplied by the cluster environment. compute-manager loads a kubeconfig that references the mounted cert files by path instead of one with the client key embedded.

## Why

- Cert rotation becomes a plain file refresh — no secret carries an assembled kubeconfig.
- Standard secret/config separation: the cert is a Secret, the kubeconfig is config.
- Both sources are optional, so compute-manager still starts where quota isn't wired.

## Changes

- `config/components/quota-credentials`: the `quota-credentials` volume becomes a projected volume over Secret `compute-edge-milo-client-cert` + ConfigMap `compute-quota-kubeconfig`. Mount path and `quotaKubeconfigPath` are unchanged.

## Related

- The cluster environment (cert Secret + kubeconfig ConfigMap) is provided by datum-cloud/infra#3216 (mount certs + static kubeconfigs).
- datum-cloud/unikraft-provider#3 — automate Unikraft runtime deployment across Datum PoPs
- datum-cloud/infra#3021 — evaluate running the Unikraft runtime on bare metal

