### PR TITLE
Schedule compute-manager on control-plane nodes in cells

### DIFF
--- a/config/overlays/cell/control-plane-scheduling-patch.yaml
+++ b/config/overlays/cell/control-plane-scheduling-patch.yaml
@@ -1,0 +1,17 @@
+# compute-manager is a cell control-plane component, so keep it on the cluster's
+# control-plane nodes and off the worker/compute nodes (which run tenant
+# workloads). Requires both the node selector and a toleration for the standard
+# control-plane taint.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: compute-manager
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule

--- a/config/overlays/cell/kustomization.yaml
+++ b/config/overlays/cell/kustomization.yaml
@@ -15,3 +15,4 @@ components:
 
 patches:
 - path: disable_webhook_patch.yaml
+- path: control-plane-scheduling-patch.yaml


### PR DESCRIPTION
## What this does

Pins the cell compute-manager to the cluster's control-plane nodes. It's a cell control-plane component, so it should run alongside the control plane and never land on worker or tenant compute nodes. Adds a node selector plus a toleration for the standard control-plane taint. Scoped to the cell overlay, so the management-plane deployment is unaffected.

## Related

- Companion to #169 (quota credential wiring) on the same cell compute-manager.
- datum-cloud/unikraft-provider#3 — automate Unikraft runtime deployment across Datum PoPs
- datum-cloud/infra#3021 — evaluate running the Unikraft runtime on bare metal
