### PR TITLE
fix(controller): register the ResourceClaim quota watch only in management-plane mode (#171)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -311,6 +311,20 @@ func main() {
 		clusterNameForProject := func(_ string) multicluster.ClusterName {
 			return multicluster.ClusterName(singleClusterName)
 		}
+
+		// Quota claim writes are REST calls to the owning project's quota API and
+		// need no local CRD, so they run in every mode. The ResourceClaim watch
+		// needs the quota CRD, which lives only on the Milo project control planes,
+		// so it is registered only in management-plane (milo) mode; engaging it in
+		// single/cluster mode would crash the manager against a cell that has no
+		// quota CRD (#171). There, grants are observed via the pending-quota
+		// requeue instead of a live watch.
+		watchProviderClaims := computeWatchProviderClaims(serverConfig.Discovery.Mode)
+		if quotaRestConfig != nil && !watchProviderClaims {
+			setupLog.Info("quota claim writes enabled without a ResourceClaim watch; "+
+				"grants are observed via the pending-quota requeue", "mode", serverConfig.Discovery.Mode)
+		}
+
 		instanceReconciler := &controller.InstanceReconciler{FederationClient: federationClient}
 		err = instanceReconciler.SetupWithManager(
 			mgr,
@@ -319,6 +333,7 @@ func main() {
 			controller.NewSingleModeProjectNamespace(mgr),
 			edgeClusterName,
 			clusterNameForProject,
+			watchProviderClaims,
 		)
 		if err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Instance")
@@ -550,4 +565,14 @@ func setupManagementControllers(mgr mcmanager.Manager, federationClient client.C
 	}
 
 	return []manager.Runnable{federationMgr}, nil
+}
+
+// computeWatchProviderClaims reports whether the direct ResourceClaim watch
+// should be registered. The watch needs the quota CRD, which lives only on the
+// Milo project control planes, so it is Milo-mode only; registering it in
+// single/cluster mode would crash the manager against a cell that has no quota
+// CRD (#171). This gates the watch only — claim writes (REST calls to the
+// owning project's quota API) run in any mode.
+func computeWatchProviderClaims(mode multiclusterproviders.Provider) bool {
+	return mode == multiclusterproviders.ProviderMilo
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	multiclusterproviders "go.miloapis.com/milo/pkg/multicluster-runtime"
+)
+
+// TestComputeWatchProviderClaims is the #171 guard: quota enforcement (and thus
+// the ResourceClaim watch) is wired only in Milo mode. Single/cluster mode must
+// stay false, so the manager never engages a ResourceClaim watch against a cell
+// that has no quota CRD.
+func TestComputeWatchProviderClaims(t *testing.T) {
+	assert.True(t, computeWatchProviderClaims(multiclusterproviders.ProviderMilo),
+		"milo mode wires the ResourceClaim watch")
+	assert.False(t, computeWatchProviderClaims(multiclusterproviders.ProviderSingle),
+		"single mode must not wire the watch (#171)")
+	assert.False(t, computeWatchProviderClaims(multiclusterproviders.ProviderKind),
+		"non-milo modes disable quota")
+}

--- a/docs/enhancements/quota-enforcement/README.md
+++ b/docs/enhancements/quota-enforcement/README.md
@@ -1,0 +1,224 @@
+---
+status: provisional
+stage: alpha
+latest-milestone: "v0.x"
+---
+
+<!--
+TODO (datum-cloud/enhancements process — not yet done):
+- Open a tracking issue in datum-cloud/enhancements and link it here. The doc's
+  final location (area directory + short title) is decided in that issue.
+- If this lands in the enhancements repo, place it under the compute area, e.g.
+  `enhancements/compute/quota-enforcement/README.md`.
+- Assign the PR to sponsoring approvers before moving status -> implementable.
+
+Status note: management-plane quota enforcement (writes + a live grant-watch) is already
+IMPLEMENTED. The proposed change is the #171 fix — wiring the live grant-watch only where
+the quota API is served locally (management-plane mode) and observing grants via the
+controller's reconcile requeue everywhere else. Quota is ENFORCED in all modes; only
+grant-observation latency differs. Overall status kept `provisional` until approved.
+-->
+
+# Quota Enforcement Across Deployment Modes
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Writes are remote API calls, available in every mode](#writes-are-remote-api-calls-available-in-every-mode)
+  - [Grant observation: live watch where served, requeue everywhere](#grant-observation-live-watch-where-served-requeue-everywhere)
+- [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+  - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+  - [Monitoring Requirements](#monitoring-requirements)
+  - [Dependencies](#dependencies)
+  - [Scalability](#scalability)
+  - [Troubleshooting](#troubleshooting)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+- [Infrastructure Needed](#infrastructure-needed)
+
+## Summary
+
+Quota enforcement works across **all** deployment modes — the management plane, edge
+cells, and flat single-tenant clusters. An Instance's quota claim is created in the Milo
+project control plane that owns the project's quota ledger, and the Instance stays gated
+until that claim is granted, wherever the manager runs. Claiming is a remote API call, so
+it needs nothing locally.
+
+The problem this enhancement fixes is that enabling quota in a **single/cluster-mode**
+deployment crashed compute-manager on startup: it tried to register a live watch for
+ResourceClaims on a local cluster that doesn't serve the quota API. The fix wires the live
+grant-watch only where the quota API is served locally (management-plane mode); everywhere
+else grants are observed through the controller's normal reconcile requeue instead. Writes
+are unaffected, enforcement stays real in every mode, and the crash cannot occur.
+
+## Motivation
+
+Quota is how the platform bounds what customers consume, and it must hold wherever compute
+runs — not just in the management plane. It already does, because claiming is a remote
+call into the owning project's quota control plane. The only thing standing in the way was
+a startup crash: pointing a single/cluster-mode deployment at quota made compute-manager
+try to watch a resource its local cluster can't serve, and it exited ([#171]). The goal is
+to keep enforcement working everywhere while making that crash impossible.
+
+[#171]: https://github.com/datum-cloud/compute/issues/171
+
+### Goals
+
+- Quota enforcement works in every deployment mode: an Instance is gated until its claim
+  is granted, whether it runs in the management plane, an edge cell, or a flat
+  single-tenant cluster.
+- Enabling quota outside the management plane must not crash compute-manager (#171).
+- Grant observation is timely where a live watch is available, and correct (if slower)
+  where it isn't.
+
+### Non-Goals
+
+- **A live grant-watch in single/cluster mode** — deferred; a per-project-control-plane
+  watch/forwarder is the future option (see [Alternatives](#alternatives)).
+- **Local (co-located) quota for flat single-tenant** — out of scope; those deployments
+  claim against the owning project's remote control plane like any other.
+- WorkloadDeployment-level quota (this covers Instance-level claims only).
+- Changes to the quota evaluator itself; this produces claims and observes grants, it does
+  not decide them.
+
+## Proposal
+
+Quota **writes** are remote calls into the owning project's quota control plane, so they
+work identically in every mode. What differs is how a **grant** is observed: a live watch
+where the quota API is served locally, and the controller's reconcile requeue elsewhere.
+Both modes enforce — an Instance stays gated until its claim is granted.
+
+| Deployment mode | How claims are written | How grants are observed | Enforced? |
+|---|---|---|---|
+| **Management plane (milo)** | Remote call to the owning project control plane | Live watch on ResourceClaims | Yes |
+| **Single / cluster** (edge cells, flat single-tenant) | Remote call to the owning project control plane | Controller reconcile requeue (backing-off re-check) — no local watch | Yes |
+
+### User Stories
+
+- As an operator, I enable quota in the management plane; customer Instances are gated on
+  grants, and the gate clears the instant a grant lands.
+- As an operator, I stand up compute-manager on a single/cluster-mode deployment
+  (edge cell or flat single-tenant) with quota configured; it starts cleanly, Instances
+  are gated on grants from their projects' quota ledgers, and the gate clears on the next
+  reconcile re-check.
+
+### Notes/Constraints/Caveats
+
+- **Project identity in single/cluster mode** is resolved from the Instance's namespace
+  mapping (the existing mechanism); writes target that project's quota control plane. No
+  fixed-project or local-quota machinery is involved.
+- Grant observation in single/cluster mode is bounded by the reconcile requeue cadence
+  rather than a live event, so a grant is noticed within the re-check interval, not
+  instantly.
+
+### Risks and Mitigations
+
+- **Grant latency in single/cluster mode.** Without a live watch, a grant is picked up on
+  the reconcile requeue (a backing-off re-check), not the moment it lands. Correctness is
+  unaffected — the Instance stays gated until granted — only the time-to-notice differs.
+  A live grant-watch is the deferred [alternative](#alternatives) if that latency ever
+  matters.
+- **Reaching the owning ledger.** If a deployment can't reach a project's quota control
+  plane, that Instance's claim can't be written or checked and it stays gated until access
+  is restored — correct (never a bypass), surfaced as recurring reconcile errors.
+
+## Design Details
+
+### Writes are remote API calls, available in every mode
+
+Claiming quota is a REST call — create/get/delete a ResourceClaim in the owning project's
+quota control plane. It needs no local quota API, so it behaves the same in
+management-plane and single/cluster modes. The owning project is resolved from the
+Instance's namespace mapping, and the claim is both written to and read back from that
+same project ledger, so a grant is always looked for where it was recorded.
+
+### Grant observation: live watch where served, requeue everywhere
+
+The one decision: the **live ResourceClaim watch is wired only where the quota API is
+served to the manager locally** — management-plane (milo) mode. That watch delivers grant
+events promptly. In single/cluster mode there is no local quota API to watch, so the watch
+is simply not registered — which is exactly the #171 crash cause removed — and grants are
+observed through the controller's reconcile requeue instead. The requeue is the universal
+floor (every mode re-checks pending claims on a backing-off schedule) and the sole
+grant-observation mechanism where no watch is wired.
+
+## Production Readiness Review Questionnaire
+
+<!-- Trimmed to the subsections relevant at alpha, following the precedent of other
+compute enhancements. Beta-targeted subsections (rollout/upgrade/rollback planning) are
+deferred. -->
+
+### Feature Enablement and Rollback
+
+- [ ] Feature gate
+- [x] Other
+  - Enforcement is enabled by configuring quota (a credential for the owning project
+    control planes); it then applies in every mode. There is no global gate.
+  - Enabling/disabling takes effect on compute-manager restart with the changed
+    configuration; no control-plane downtime.
+  - Rollback is removing the quota configuration; enforcement stops.
+
+### Monitoring Requirements
+
+- [x] API .status
+  - The Instance's quota-granted status condition shows whether an Instance is gated or
+    granted, in every mode. A persistently ungated Instance indicates a pending grant or a
+    ledger the deployment can't reach.
+
+### Dependencies
+
+- Milo quota evaluator and the per-project quota control planes it serves — the authority
+  that grants or denies claims, and the target of every claim write and read. If a
+  deployment can't reach them, claims stay pending and Instances stay gated (no bypass).
+
+### Scalability
+
+- Writes add per-Instance claim calls to the owning project control planes (present
+  already). Single/cluster mode registers no ResourceClaim watch, so it adds no per-project
+  watch load; grant re-checks ride the existing reconcile requeue.
+
+### Troubleshooting
+
+- **compute-manager crashes on startup with quota configured in single/cluster mode:**
+  that is #171; with this change the live watch isn't wired in those modes, so it is never
+  registered and the crash cannot occur — grants come from the requeue instead.
+- **Instances stuck ungated:** confirm the deployment can reach the owning project control
+  planes and that those projects are entitled, so claims are granted rather than left
+  pending.
+
+## Implementation History
+
+- Management-plane claim routing and the live watch on project control planes:
+  **implemented** (verified 2026-05-26).
+- The #171 fix — wiring the live grant-watch only where the quota API is served locally and
+  observing grants via the reconcile requeue elsewhere: **proposed** here.
+
+## Drawbacks
+
+- In single/cluster mode a grant is noticed on the reconcile requeue cadence rather than
+  instantly — a grant-latency cost relative to the management plane's live watch.
+  Enforcement is unaffected; only responsiveness differs.
+
+## Alternatives
+
+- **A live grant-watch in single/cluster mode via a per-project-control-plane watch or
+  forwarder** — *deferred*. It would deliver grants promptly there too, but needs one watch
+  per project a deployment serves (per-project fan-out), and the reconcile requeue already
+  keeps enforcement correct. Revisit if grant latency in those modes ever becomes a product
+  concern.
+- **Local co-located quota for flat single-tenant** — rejected; claims target the owning
+  project's control plane like every other mode, so no local quota ledger is needed.
+
+## Infrastructure Needed
+
+- None beyond the shipped management-plane setup. Enforcement in single/cluster mode reuses
+  the same remote claim writes and the existing reconcile requeue; a future live grant-watch
+  there (see [Alternatives](#alternatives)) would bring its own platform-side access needs,
+  tracked then.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -286,8 +286,10 @@ type DiscoveryConfig struct {
 	// takes precedence over ProjectKubeconfigPath for quota calls. When both are
 	// unset, quota accounting is disabled.
 	//
-	// Use this field in deployments (mode: single or mode: milo) that need to
-	// talk to api.datum.net for quota enforcement.
+	// Setting it enables quota enforcement (claim writes to the owning project's
+	// quota API) in any mode. The live ResourceClaim watch, however, runs only in
+	// management-plane mode; single/cluster deployments observe grants via the
+	// reconcile requeue instead.
 	QuotaKubeconfigPath string `json:"quotaKubeconfigPath"`
 }
 

--- a/internal/controller/instance_controller.go
+++ b/internal/controller/instance_controller.go
@@ -1796,6 +1796,30 @@ func (r *InstanceReconciler) resolveClusterNameForProject(projectID string) mult
 	return multicluster.ClusterName(projectID)
 }
 
+// mapClaimToInstanceRequest maps a granted ResourceClaim back to a reconcile
+// request for its owning Instance. The Instance namespace is carried on a label
+// (the claim itself lives in the project's quota namespace) and the Instance
+// name is the claim name with the resource-kind prefix stripped. Returns nil
+// when the namespace label is absent, so a claim not stamped by this controller
+// is ignored.
+func (r *InstanceReconciler) mapClaimToInstanceRequest(claim *quotav1alpha1.ResourceClaim) []mcreconcile.Request {
+	instanceNamespace := claim.GetLabels()[instanceQuotaClaimNamespaceLabel]
+	if instanceNamespace == "" {
+		return nil
+	}
+	return []mcreconcile.Request{
+		{
+			Request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: instanceNamespace,
+					Name:      strings.TrimPrefix(claim.Name, instanceQuotaClaimNamePrefix),
+				},
+			},
+			ClusterName: r.resolveClusterNameForProject(claim.Spec.ConsumerRef.Name),
+		},
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 //
 // quotaRestConfig is the REST config used to reach Milo project control planes
@@ -1809,6 +1833,16 @@ func (r *InstanceReconciler) resolveClusterNameForProject(projectID string) mult
 // clusterNameForProject maps a project ID back to the multicluster ClusterName.
 // In Milo mode pass nil (falls back to ClusterName(projectID)). In single-cell
 // mode pass a function that always returns "single".
+//
+// watchProviderClaims registers the direct ResourceClaim watch on provider
+// clusters. It is independent of quotaRestConfig: claim writes (CRUD) run
+// whenever quotaRestConfig is set, in any mode, because they are REST calls to
+// the owning project's quota API and need no local CRD. The watch, however,
+// needs the quota CRD, which lives only on the Milo project control planes, so
+// pass true only in Milo mode. In single/cluster mode pass false (with a non-nil
+// quotaRestConfig): claim writes still work, but no watch is registered, so the
+// manager never engages a ResourceClaim watch against a cell with no quota CRD
+// (#171); grants are observed via the pending-quota requeue.
 func (r *InstanceReconciler) SetupWithManager(
 	mgr mcmanager.Manager,
 	quotaRestConfig *rest.Config,
@@ -1816,6 +1850,7 @@ func (r *InstanceReconciler) SetupWithManager(
 	projectNamespaceForInstance InstanceProjectNamespaceFunc,
 	edgeClusterName string,
 	clusterNameForProject func(projectID string) multicluster.ClusterName,
+	watchProviderClaims bool,
 ) error {
 	r.mgr = mgr
 	r.scheme = mgr.GetLocalManager().GetScheme()
@@ -1841,40 +1876,34 @@ func (r *InstanceReconciler) SetupWithManager(
 
 	edgeClusterNameVal := r.edgeClusterName
 
-	return mcbuilder.ControllerManagedBy(mgr).
-		For(&computev1alpha.Instance{}, mcbuilder.WithEngageWithLocalCluster(false)).
-		Watches(
+	b := mcbuilder.ControllerManagedBy(mgr).
+		For(&computev1alpha.Instance{}, mcbuilder.WithEngageWithLocalCluster(false))
+
+	// The direct ResourceClaim watch resolves the quota.miloapis.com CRD only on
+	// the Milo project control planes, so the caller gates registration on
+	// watchProviderClaims (milo mode only); in single/cluster mode it is never
+	// registered, so the manager can't engage it against a cell that has no quota
+	// CRD (#171). Claim writes are unaffected — they run wherever quotaRestConfig
+	// is set.
+	if watchProviderClaims {
+		b = b.Watches(
 			&quotav1alpha1.ResourceClaim{},
 			func(_ multicluster.ClusterName, _ cluster.Cluster) handler.TypedEventHandler[client.Object, mcreconcile.Request] {
 				return handler.TypedEnqueueRequestsFromMapFunc(
-					func(ctx context.Context, obj client.Object) []mcreconcile.Request {
-						claim := obj.(*quotav1alpha1.ResourceClaim)
-						// Map the claim back to its owning Instance. The Instance
-						// namespace is carried on a label (the claim itself lives in
-						// the project's quota namespace) and the Instance name is the
-						// claim name with the resource-kind prefix stripped.
-						instanceNamespace := claim.GetLabels()[instanceQuotaClaimNamespaceLabel]
-						if instanceNamespace == "" {
-							return nil
-						}
-						return []mcreconcile.Request{
-							{
-								Request: reconcile.Request{
-									NamespacedName: types.NamespacedName{
-										Namespace: instanceNamespace,
-										Name:      strings.TrimPrefix(claim.Name, instanceQuotaClaimNamePrefix),
-									},
-								},
-								ClusterName: r.resolveClusterNameForProject(claim.Spec.ConsumerRef.Name),
-							},
-						}
+					func(_ context.Context, obj client.Object) []mcreconcile.Request {
+						return r.mapClaimToInstanceRequest(obj.(*quotav1alpha1.ResourceClaim))
 					},
 				)
 			},
+			mcbuilder.WithEngageWithProviderClusters(true),
+			mcbuilder.WithEngageWithLocalCluster(false),
 			mcbuilder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
 				return obj.GetLabels()[instanceQuotaClaimSourceLabel] == edgeClusterNameVal
 			})),
-		).
+		)
+	}
+
+	return b.
 		// Watch companion ConfigMaps: when one arrives (or is updated) re-queue all
 		// Instances in the namespace so they can attempt gate-clearing.
 		Watches(&corev1.ConfigMap{}, func(clusterName multicluster.ClusterName, cl cluster.Cluster) handler.TypedEventHandler[client.Object, mcreconcile.Request] {

--- a/internal/controller/instance_setup_test.go
+++ b/internal/controller/instance_setup_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+	mcsingle "sigs.k8s.io/multicluster-runtime/providers/single"
+)
+
+// startupObservationWindow is how long the manager must stay up before we accept
+// that it started cleanly. The #171 failure (a watch whose kind has no CRD)
+// surfaces during cache sync well under a second, so this only needs to be long
+// enough to give a regressed build the chance to crash.
+const startupObservationWindow = 5 * time.Second
+
+// startComputeEnvtest boots an API server with only the compute CRDs installed —
+// deliberately WITHOUT quota.miloapis.com — reproducing the edge-cell topology
+// from #171 where ResourceClaim has no CRD on the cell cluster.
+func startComputeEnvtest(t *testing.T) *rest.Config {
+	t.Helper()
+	env := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "base", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+	// Respect KUBEBUILDER_ASSETS (set by `make test`); fall back to the assets
+	// `setup-envtest` writes under bin/ for local `go test` runs.
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		env.BinaryAssetsDirectory = filepath.Join("..", "..", "bin", "k8s",
+			fmt.Sprintf("1.31.0-%s-%s", runtime.GOOS, runtime.GOARCH))
+	}
+
+	cfg, err := env.Start()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	t.Cleanup(func() { _ = env.Stop() })
+	return cfg
+}
+
+// TestInstanceSetupWithManager_SingleModeNoQuotaCRD is the #171 regression test.
+// On an edge cell (single mode) the only registered cluster is the local cell,
+// which has no quota.miloapis.com CRD. With quota configured but the watch gated
+// off (watchProviderClaims=false), the quota client (claim writes) must be wired
+// while the manager still starts cleanly — a build that registered the watch
+// would crash here during cache sync with `no matches for kind "ResourceClaim"`.
+func TestInstanceSetupWithManager_SingleModeNoQuotaCRD(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stderr)))
+
+	cfg := startComputeEnvtest(t)
+	scheme := newTestScheme(t)
+
+	deploymentCluster, err := cluster.New(cfg, func(o *cluster.Options) { o.Scheme = scheme })
+	require.NoError(t, err)
+
+	// The single provider registers only the local cell cluster, mirroring
+	// cmd/main.go's mcsingle.New for an edge cell.
+	provider := mcsingle.New(multicluster.ClusterName("single"), deploymentCluster)
+	mgr, err := mcmanager.New(cfg, provider, ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+	})
+	require.NoError(t, err)
+
+	r := &InstanceReconciler{}
+	require.NoError(t, r.SetupWithManager(
+		mgr,
+		cfg, // quotaRestConfig set: claim writes are wired even in single mode
+		NewSingleModeProjectID(mgr),
+		NewSingleModeProjectNamespace(mgr),
+		"test-edge",
+		func(string) multicluster.ClusterName { return multicluster.ClusterName("single") },
+		false, // watchProviderClaims: the fix — do not engage the ResourceClaim watch on the cell
+	))
+
+	// Claim writes (CRUD) are wired in single mode; only the watch is skipped.
+	require.NotNil(t, r.quotaClientManager, "quota client must be wired for claim writes in single mode")
+
+	// The single provider does not start the cluster it engages, so — like
+	// cmd/main.go — the cluster and the manager run as sibling goroutines.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 2)
+	go func() { errCh <- deploymentCluster.Start(ctx) }()
+	go func() { errCh <- mgr.Start(ctx) }()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("manager exited during startup, want it to stay up: %v", err)
+	case <-time.After(startupObservationWindow):
+		// Stayed up with no ResourceClaim watch engaged despite quota being
+		// configured: writes are on, the watch is off, #171 is fixed.
+	}
+}


### PR DESCRIPTION
## Summary

Enabling quota enforcement on a compute deployment outside the central management plane crashed compute-manager on startup (#171): it tried to watch ResourceClaims, but in single/cluster mode the quota API isn't served locally, so the informer had nothing to resolve. This registers the live grant-watch only where the quota API is available; single/cluster deployments observe grants via the controller's reconcile requeue instead. Quota is still enforced in every mode.

## What changed

Claiming quota is a remote API call — the controller creates, reads, and deletes a ResourceClaim in the owning project's quota control plane — so it works in every deployment mode and is unchanged. Only grant observation differs: management-plane mode keeps the live ResourceClaim watch; single/cluster mode has no local quota API to watch, so it picks up grants on the controller's backing-off requeue. Registering the watch only where the quota API is served is the #171 fix. An Instance stays gated until its claim is granted either way — enforcement is real; only grant latency differs.

## Testing

`go build`/`vet`/`gofmt` and `go test` (with envtest) all green. A decision test guards that the ResourceClaim watch is registered only in management-plane mode; an envtest confirms a single-mode manager — quota writes wired, no local quota API — starts cleanly with the watch off; and the pending-quota requeue is covered.

## Notes

Single/cluster grant observation is bounded by the requeue cadence (seconds, backing off) rather than instant — correctness is unaffected. A live grant-watch for single/cluster mode is deferred; the design and future options are in the enhancement.

Fixes #171. Design: `docs/enhancements/quota-enforcement/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
