### PR TITLE
chore: migrate .goreleaser-plugin.yaml to goreleaser v2 archives schema

### DIFF
--- a/.goreleaser-plugin.yaml
+++ b/.goreleaser-plugin.yaml
@@ -25,9 +25,10 @@ builds:
 
 archives:
   - id: datumctl-compute
-    builds:
+    ids:
       - datumctl-compute
-    format: tar.gz
+    formats:
+      - tar.gz
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
@@ -37,7 +38,8 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
## Why

Keeps `datumctl-compute` CLI plugin releases reliable. Every plugin release currently emits three goreleaser deprecation warnings, and a future goreleaser major that drops the old keys would break the release pipeline outright — blocking users from receiving CLI plugin updates. Migrating now removes that time bomb with zero change to the published artifacts.

> [!NOTE]
> This PR targets `feat/datumctl-compute-plugin` rather than `main` because `.goreleaser-plugin.yaml` (and the plugin source it builds, `cmd/datumctl-compute`) only exist on that branch, which is where plugin releases are cut from.

## What changed

Migrated `.goreleaser-plugin.yaml` to the current goreleaser v2 archives schema per https://goreleaser.com/deprecations:

| Deprecated key | Replacement |
| --- | --- |
| `archives.builds` | `archives.ids` |
| `archives.format` | `archives.formats` (list) |
| `archives.format_overrides.format` | `archives.format_overrides.formats` (list) |

No other deprecated keys are present in the file (confirmed via `goreleaser check` and a clean release run).

## Verification

Ran `goreleaser release --snapshot --clean --skip=publish --config .goreleaser-plugin.yaml` (goreleaser 2.16.0) before and after the change, re-verified after rebasing onto the latest base branch.

**Before:** three deprecation warnings:

```
• DEPRECATED: archives.format should not be used anymore
• DEPRECATED: archives.format_overrides.format should not be used anymore
• DEPRECATED: archives.builds should not be used anymore
```

**After:** zero deprecation warnings, `goreleaser check` passes, and the snapshot produces the same six platform archives with byte-identical names:

```
datumctl-compute_Darwin_arm64.tar.gz
datumctl-compute_Darwin_x86_64.tar.gz
datumctl-compute_Linux_arm64.tar.gz
datumctl-compute_Linux_x86_64.tar.gz
datumctl-compute_Windows_arm64.zip
datumctl-compute_Windows_x86_64.zip
```

`golangci-lint run` (v2.12.2, the CI-pinned version) reports 0 issues on the rebased head. An earlier revision of this PR carried lint fixes for the branch; those landed on the base branch independently (cb02956), so this PR is now the goreleaser migration only.

Fixes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)