### PR TITLE
fix(compute): edge cells start cleanly by defaulting networking integration off (#114)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -116,8 +116,8 @@ func main() {
 	var featureGatesFlag string
 	flag.StringVar(&featureGatesFlag, "feature-gates", "",
 		"A set of key=value pairs that describe feature gates for the compute operator. "+
-			"Example: --feature-gates=NetworkingIntegration=false. "+
-			"Available features: NetworkingIntegration (default=true).")
+			"Example: --feature-gates=NetworkingIntegration=true. "+
+			"Available features: NetworkingIntegration (default=false).")
 
 	opts := zap.Options{
 		Development: true,

--- a/internal/controller/workloaddeployment_controller.go
+++ b/internal/controller/workloaddeployment_controller.go
@@ -53,7 +53,7 @@ type WorkloadDeploymentReconciler struct {
 	// network-services-operator is active. When false, NetworkBinding creation is
 	// skipped, the Network scheduling gate is never added to Instances (and is
 	// actively removed if present), and the networking step is treated as
-	// immediately ready. Defaults to true.
+	// immediately ready. Defaults to false.
 	NetworkingEnabled bool
 
 	// enableReferencedDataGate mirrors FeatureFlagsConfig.EnableReferencedDataGate.

--- a/internal/controller/workloaddeployment_setup_test.go
+++ b/internal/controller/workloaddeployment_setup_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package controller
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+	mcsingle "sigs.k8s.io/multicluster-runtime/providers/single"
+
+	computev1alpha "go.datum.net/compute/api/v1alpha"
+	networkingv1alpha "go.datum.net/network-services-operator/api/v1alpha"
+)
+
+// TestWorkloadDeploymentSetupWithManager_CellModeNoNetworkingCRD asserts that with
+// the networking integration disabled the WorkloadDeployment reconciler starts
+// cleanly on an edge cell that carries no networking.datumapis.com CRDs. The only
+// registered cluster is the local cell; a build that left networking enabled would
+// register the NetworkBinding/Location/SubnetClaim/Subnet watches and crash during
+// cache sync with no matches for those kinds.
+func TestWorkloadDeploymentSetupWithManager_CellModeNoNetworkingCRD(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stderr)))
+
+	cfg := startComputeEnvtest(t)
+
+	// Register the networking types in the scheme but leave their CRDs absent from
+	// the API server (startComputeEnvtest installs compute CRDs only). Enabling the
+	// watches then fails at cache sync — the real cell failure — rather than at
+	// Complete() with a scheme lookup error.
+	scheme := runtime.NewScheme()
+	require.NoError(t, computev1alpha.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, networkingv1alpha.AddToScheme(scheme))
+
+	deploymentCluster, err := cluster.New(cfg, func(o *cluster.Options) { o.Scheme = scheme })
+	require.NoError(t, err)
+
+	// The single provider registers only the local cell cluster, mirroring
+	// cmd/main.go's mcsingle.New for an edge cell.
+	provider := mcsingle.New(multicluster.ClusterName("single"), deploymentCluster)
+	mgr, err := mcmanager.New(cfg, provider, ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+	})
+	require.NoError(t, err)
+
+	r := &WorkloadDeploymentReconciler{NetworkingEnabled: false}
+	require.NoError(t, r.SetupWithManager(mgr))
+
+	// The single provider does not start the cluster it engages, so — like
+	// cmd/main.go — the cluster and the manager run as sibling goroutines.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 2)
+	go func() { errCh <- deploymentCluster.Start(ctx) }()
+	go func() { errCh <- mgr.Start(ctx) }()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("manager exited during startup, want it to stay up: %v", err)
+	case <-time.After(startupObservationWindow):
+		// Stayed up with no networking watches engaged despite the networking types
+		// having no CRD on the cell: the WD reconciler is crash-safe by default.
+	}
+}

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -33,8 +33,11 @@ const (
 	//     proceed to the runtime without a NetworkBinding.
 	//
 	// This flag exists so operators can run compute on edge/lab cells where
-	// VPC/NSO is not yet functional. The default is true (enabled) so that
-	// existing production deployments are unaffected.
+	// VPC/NSO is not yet functional. The default is disabled: cells carry no
+	// networking.datumapis.com CRDs, and registering a watch for an absent CRD
+	// wedges the manager's cache sync and crash-loops it. Deployments that run
+	// network-services-operator opt in with
+	// --feature-gates=NetworkingIntegration=true.
 	//
 	// alpha: v0.1
 	NetworkingIntegration featuregate.Feature = "NetworkingIntegration"
@@ -53,7 +56,7 @@ var FeatureGate featuregate.FeatureGate = MutableFeatureGate
 
 func init() {
 	if err := MutableFeatureGate.Add(map[featuregate.Feature]featuregate.FeatureSpec{
-		NetworkingIntegration: {Default: true, PreRelease: featuregate.Alpha},
+		NetworkingIntegration: {Default: false, PreRelease: featuregate.Alpha},
 	}); err != nil {
 		panic(err)
 	}

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -6,14 +6,14 @@ import (
 	"testing"
 )
 
-// TestNetworkingIntegration_DefaultEnabled verifies that the NetworkingIntegration
-// feature gate defaults to enabled so that existing production deployments are
-// unaffected when the flag is not set.
-func TestNetworkingIntegration_DefaultEnabled(t *testing.T) {
+// TestNetworkingIntegration_DefaultDisabled verifies that the NetworkingIntegration
+// feature gate defaults to disabled so cells, which carry no networking CRDs, come
+// up crash-safe when the flag is not set; deployments running NSO opt in explicitly.
+func TestNetworkingIntegration_DefaultDisabled(t *testing.T) {
 	// Use a fresh gate so this test is independent of any global state mutations.
 	gate := MutableFeatureGate.DeepCopy()
-	if !gate.Enabled(NetworkingIntegration) {
-		t.Error("NetworkingIntegration default = false, want true")
+	if gate.Enabled(NetworkingIntegration) {
+		t.Error("NetworkingIntegration default = true, want false")
 	}
 }
 


### PR DESCRIPTION
The compute-manager deployed to edge cells from the shipped cell overlay crash-loops at startup: it watches networking CRDs (`Subnet`, `SubnetClaim`, `NetworkBinding`) that exist only on control planes, so its cache never syncs and edge compute goes offline. This PR makes the shipped artifact start cleanly by default — networking integration becomes opt-in (`--feature-gates=NetworkingIntegration=true`) for deployments running network-services-operator. It also fixes the same latent startup crash in the single-cluster quickstart path.

`Fixes #114.` #172 already fixed the quota-watch half; this completes the issue.

A default flip rather than an overlay patch because no deployment relies on the old default — production edge cells already set the gate false via infra's Flux patch, so production behavior is unchanged.

**Changes**
- Flip the `NetworkingIntegration` feature-gate default to off, and update the flag help accordingly.
- Invert the default-gate test so the crash-prone default can't silently return.
- Add a cell-mode envtest that boots the reconciler against a compute-only API server and reproduces the crash when the guard is bypassed.

Build, vet, and the full test suite are green.

**Follow-ups (separate PRs)**
- Pre-flight CRD check for a legible fail-fast instead of a cache-sync timeout.
- Gate the unconditional `Network` watch in management mode (same bug class).
- Drop the now-redundant gate line from infra's edge manager-patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
