### PR TITLE
fix(instance): honor NetworkingIntegration gate so instances schedule without networking CRDs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -325,7 +325,10 @@ func main() {
 				"grants are observed via the pending-quota requeue", "mode", serverConfig.Discovery.Mode)
 		}
 
-		instanceReconciler := &controller.InstanceReconciler{FederationClient: federationClient}
+		instanceReconciler := &controller.InstanceReconciler{
+			FederationClient:  federationClient,
+			NetworkingEnabled: features.FeatureGate.Enabled(features.NetworkingIntegration),
+		}
 		err = instanceReconciler.SetupWithManager(
 			mgr,
 			quotaRestConfig,

--- a/internal/controller/instance_controller.go
+++ b/internal/controller/instance_controller.go
@@ -233,7 +233,15 @@ type InstanceReconciler struct {
 	// management cluster) can aggregate status across all POP cells. Set to nil to
 	// disable federation write-back (e.g. in non-federation deployments).
 	FederationClient client.Client
-	finalizers       finalizer.Finalizers
+	// NetworkingEnabled mirrors the NetworkingIntegration feature gate. When false
+	// the reconciler skips the NetworkBinding readiness check: cells without the
+	// networking CRDs installed would otherwise fail every reconcile on a
+	// "no matches for kind NetworkBinding" RESTMapper error, aborting before the
+	// scheduling gates are cleared and wedging the instance in Pending. The
+	// WorkloadDeployment controller honors the same gate for NetworkBinding
+	// creation and the Network scheduling gate.
+	NetworkingEnabled bool
+	finalizers        finalizer.Finalizers
 }
 
 // +kubebuilder:rbac:groups=compute.datumapis.com,resources=instances,verbs=get;list;watch;create;update;patch;delete
@@ -1771,6 +1779,15 @@ func (r *InstanceReconciler) reconcileInstanceReadyCondition(
 // Rough way to propagate creation errors up to the instance as soon as possible.
 // Lots of room for improvement here.
 func (r *InstanceReconciler) checkForNetworkCreationFailure(ctx context.Context, upstreamClient client.Client, instance *computev1alpha.Instance) (failed bool, message string, err error) {
+	// When the networking integration is disabled there are no NetworkBindings to
+	// check. The NetworkBinding CRD is not installed on cells that don't run the
+	// networking integration, so this lookup would otherwise fail with a
+	// "no matches for kind NetworkBinding" RESTMapper error and wedge the reconcile
+	// before the scheduling gates are cleared. Report no failure.
+	if !r.NetworkingEnabled {
+		return false, "", nil
+	}
+
 	workloadDeployment, err := r.fetchOwnerWorkloadDeployment(ctx, upstreamClient, instance)
 	if err != nil {
 		return false, "", fmt.Errorf("failed fetching workload deployment: %w", err)

--- a/internal/controller/instance_controller_test.go
+++ b/internal/controller/instance_controller_test.go
@@ -679,6 +679,9 @@ func TestReconcileQuota(t *testing.T) {
 		claim := makeClaim(s, metav1.ConditionTrue, quotav1alpha1.ResourceClaimGrantedReason)
 
 		r, projectClient, _ := newReconciler(t, []client.Object{instance, makeDeployment()}, []client.Object{claim})
+		// The network failure checker only runs when the networking integration is
+		// enabled; enable it so this test exercises that path.
+		r.NetworkingEnabled = true
 
 		_, err := r.Reconcile(context.Background(), mcreconcile.Request{Request: reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: instanceName}}, ClusterName: clusterName})
 		require.Error(t, err)
@@ -2589,6 +2592,27 @@ func TestReconcileInstanceReadyCondition_ReferencedDataEnrichment(t *testing.T) 
 			assert.Contains(t, cond.Message, tt.wantMsgContains)
 		})
 	}
+}
+
+// TestCheckForNetworkCreationFailure_NetworkingDisabled verifies that when the
+// networking integration is disabled the check is a no-op and never touches the
+// client. On cells that don't run the networking integration the NetworkBinding
+// CRD is absent, so a lookup would fail with a "no matches for kind NetworkBinding"
+// RESTMapper error and wedge the reconcile before scheduling gates are cleared.
+// A nil client here would panic if the method attempted any lookup.
+func TestCheckForNetworkCreationFailure_NetworkingDisabled(t *testing.T) {
+	instance := &computev1alpha.Instance{
+		Spec: computev1alpha.InstanceSpec{
+			// A network interface would normally drive a NetworkBinding lookup.
+			NetworkInterfaces: []computev1alpha.InstanceNetworkInterface{{}},
+		},
+	}
+
+	r := &InstanceReconciler{NetworkingEnabled: false}
+	failed, msg, err := r.checkForNetworkCreationFailure(context.Background(), nil, instance)
+	require.NoError(t, err)
+	assert.False(t, failed)
+	assert.Empty(t, msg)
 }
 
 // TestReconcileInstanceReadyCondition_EvaluateAllThenPick verifies that all


### PR DESCRIPTION
## Why

On cells that run with the networking integration disabled (`NetworkingIntegration=false`), compute instances get quota granted but never schedule — they sit in Pending forever.

The Instance reconciler checks for a failed `NetworkBinding` on every reconcile. That CRD isn't installed on cells that don't run the networking integration, so the lookup fails with a `no matches for kind "NetworkBinding"` RESTMapper error. That error aborts the reconcile before it clears the instance's `Quota` scheduling gate — so the gate never clears, the provider never programs the instance, and it stays Pending even though quota was granted.

The WorkloadDeployment controller already honors the `NetworkingIntegration` gate (it skips `NetworkBinding` creation and the Network scheduling gate when disabled). The Instance reconciler didn't — it ran the `NetworkBinding` check unconditionally, so the feature gate's off-switch wasn't actually effective end to end.

## What this changes

The Instance reconciler now honors the same `NetworkingIntegration` feature gate: when networking is disabled it skips the `NetworkBinding` readiness check. With the check skipped, the reconcile completes, the `Quota` scheduling gate clears once quota is granted, and the instance is programmed and scheduled.

No behavior change when networking is enabled — the check runs exactly as before. Added a unit test asserting the check is a no-op (and never touches the client) when networking is disabled.

## Context

Surfaced bringing compute up on the `datum-us-central-1-lab` edge cell, which runs `FEATURE_GATES=NetworkingIntegration=false` and does not install the `NetworkBinding` CRD (an upstream/management-plane resource, not part of the downstream CRD set). Quota was healthy; the instance was wedged solely by this check erroring on the absent CRD.

## Related

- #114 — same class of bug: compute-manager in cell mode touching upstream-only CRDs on the local cell cluster. `NetworkBinding` is upstream-only, so the Instance reconciler's readiness check hit "no matches for kind" on cells that don't run the networking integration.
- #171 — sibling cell-mode crash where the ResourceClaim watch engaged the local cell cluster in single-cell mode.
- #112 — the network-services-operator integration this feature gate governs; the check should stay disabled until that integration is available on the cell.
- datum-cloud/infra#3618 — sibling fix from the same edge-cell bring-up (unblocked quota); this clears the scheduling wedge that surfaced immediately after.
