### PR TITLE
fix(workload): stop hot-looping idle WorkloadDeployments by merging metadata

### DIFF
--- a/internal/controller/workload_controller.go
+++ b/internal/controller/workload_controller.go
@@ -189,8 +189,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req mcreconcile.Requ
 				logger.Info("updating deployment", "deployment_name", deployment.Name)
 			}
 
-			deployment.Annotations = desiredDeployment.Annotations
-			deployment.Labels = desiredDeployment.Labels
+			mergeDeploymentMetadata(deployment, &desiredDeployment)
 
 			// TODO(jreese) consider how this plays well with autoscaling
 			deployment.Spec = desiredDeployment.Spec
@@ -506,6 +505,19 @@ func (r *WorkloadReconciler) getDeploymentsForWorkload(
 	}
 
 	return desired, orphaned, nil
+}
+
+// mergeDeploymentMetadata copies the controller-owned labels and annotations
+// from desired onto deployment without discarding peer-owned keys. Only the
+// spec is fully owned by this controller; metadata is shared with the
+// referenced-data controller (which stamps the expected-referenced-data
+// annotation) and the federation hub (which stamps propagation bookkeeping).
+// A wholesale map replacement here would strip those keys, and because both
+// controllers watch the same WorkloadDeployment, each write re-triggered the
+// other in an annotation ping-pong that hot-looped otherwise-idle deployments.
+func mergeDeploymentMetadata(deployment, desired *computev1alpha.WorkloadDeployment) {
+	mergeLabels(deployment, desired.Labels)
+	mergeAnnotations(deployment, desired.Annotations)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/workload_controller_test.go
+++ b/internal/controller/workload_controller_test.go
@@ -200,6 +200,54 @@ func TestReconcileWorkloadStatus_ObservedGeneration(t *testing.T) {
 		"Available condition ObservedGeneration must equal workload.Generation")
 }
 
+// TestMergeDeploymentMetadata_PreservesForeignAnnotation verifies that merging
+// the controller-owned desired metadata onto an existing WorkloadDeployment
+// writes the desired keys while preserving peer-owned metadata — in particular
+// the referenced-data controller's expected-referenced-data annotation. A blind
+// map overwrite here strips that annotation and drives the reconcile hot-loop
+// described in issue #191, so this test fails if the merge is regressed to an
+// overwrite.
+func TestMergeDeploymentMetadata_PreservesForeignAnnotation(t *testing.T) {
+	const foreignVal = `["ConfigMap/app-config"]`
+
+	// The live object as it exists after the referenced-data controller has
+	// stamped its annotation and Karmada has stamped a bookkeeping label.
+	existing := &computev1alpha.WorkloadDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wd-1",
+			Namespace: testDefaultNamespace,
+			Labels: map[string]string{
+				"work.karmada.io/managed": "true",
+			},
+			Annotations: map[string]string{
+				computev1alpha.ExpectedReferencedDataAnnotation: foreignVal,
+			},
+		},
+	}
+
+	// The desired object the workload controller builds carries only its own
+	// ownership label and no annotations.
+	desired := &computev1alpha.WorkloadDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				computev1alpha.WorkloadUIDLabel: "workload-uid-123",
+			},
+		},
+	}
+
+	mergeDeploymentMetadata(existing, desired)
+
+	// Desired controller-owned key is written.
+	assert.Equal(t, "workload-uid-123", existing.Labels[computev1alpha.WorkloadUIDLabel],
+		"desired WorkloadUIDLabel must be written")
+
+	// Peer-owned annotation and label survive.
+	assert.Equal(t, foreignVal, existing.Annotations[computev1alpha.ExpectedReferencedDataAnnotation],
+		"expected-referenced-data annotation must be preserved across merge")
+	assert.Equal(t, "true", existing.Labels["work.karmada.io/managed"],
+		"federation-hub bookkeeping label must be preserved across merge")
+}
+
 // TestWorkloadBlockingReasonPriority exhaustively verifies every entry in the
 // workloadBlockingReasonPriority switch statement.
 func TestWorkloadBlockingReasonPriority(t *testing.T) {


### PR DESCRIPTION
## What this changes for the platform

Idle Workloads were being reconciled continuously on the project control planes even though nothing about them changed. This burns control-plane capacity and adds constant write churn to every project running compute. This change stops that wasteful re-reconciliation, so idle Workloads settle and stay quiet, reducing load on project control planes.

## Root cause

The management-mode WorkloadReconciler builds a desired WorkloadDeployment carrying only its own ownership label, then in the `CreateOrUpdate` mutate it replaced the live object's entire label and annotation maps. That blind overwrite stripped metadata owned by other controllers on the same WorkloadDeployment — specifically the referenced-data controller's `compute.datumapis.com/expected-referenced-data` annotation and federation-hub bookkeeping keys. Those controllers re-applied their keys immediately, which re-triggered the workload controller, which overwrote them again. Because the workload controller `Owns` the WorkloadDeployment while the referenced-data controller and the federator watch it, every write re-enqueued all three in an annotation ping-pong. The object generation never changed, so it looked like metadata-only churn with no obvious cause.

## The fix

Merge the controller-owned desired labels and annotations onto the existing object instead of replacing the maps, preserving peer-owned keys. This reuses the same `mergeLabels`/`mergeAnnotations` helpers the referenced-data controller already uses for the identical concern on companion objects. The Spec is fully owned by this controller and is still assigned wholesale.

## Tests

Added a focused unit test (`TestMergeDeploymentMetadata_PreservesForeignAnnotation`) that seeds a WorkloadDeployment with a pre-existing foreign `expected-referenced-data` annotation plus a federation bookkeeping label, runs the merge, and asserts the desired ownership label is written while the peer-owned annotation and label survive. This test fails if the merge is ever regressed back to a wholesale overwrite. It runs as a plain `go test` unit test (no envtest / KUBEBUILDER_ASSETS required).

Part of #191