### PR TITLE
feat(alerts): page on compute controller reconcile storms

### DIFF
--- a/config/components/alerts/kustomization.yaml
+++ b/config/components/alerts/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - reconcile-storm.yaml

--- a/config/components/alerts/reconcile-storm.yaml
+++ b/config/components/alerts/reconcile-storm.yaml
@@ -4,92 +4,92 @@ metadata:
   labels:
     alert-group: compute
     app.kubernetes.io/name: compute
-    app.kubernetes.io/component: management-controllers
+    app.kubernetes.io/component: controllers
     app.kubernetes.io/managed-by: kustomize
-  name: compute-management-controller-alerts
+  name: compute-controller-alerts
 spec:
   groups:
-    - name: compute-management-controllers.reconcile-storm
+    - name: compute-controllers.reconcile-storm
       rules:
-        # Management controllers (workload, referenced-data,
-        # workload-deployment-federator) re-reconcile idle Workloads in a
-        # self-perpetuating loop: reconciles keep succeeding but produce no work,
-        # so the fingerprint is a high reconcile rate while the workqueue stays
-        # drained. reconcile_errors_total stays flat, so error-based alerts miss
-        # this entirely.
-        - alert: ComputeManagementControllerReconcileStorm
+        # A reconcile storm is a generic controller-runtime pathology: a
+        # controller re-reconciles the same objects in a self-perpetuating loop.
+        # Reconciles keep succeeding, so reconcile_errors_total stays flat and
+        # error-based alerting misses it entirely. The fingerprint is a high
+        # reconcile rate while the workqueue stays drained. Evaluated per
+        # controller across every controller compute-manager reports (job label
+        # scopes to compute-manager; the controller/name label identifies which
+        # one is storming when it fires) so it also covers cell-side controllers
+        # and any controller added later. The drained-queue guard keeps a
+        # legitimately busy controller (deep backlog) from tripping it.
+        - alert: ComputeControllerReconcileStorm
           expr: |
             (
               sum by (controller) (
-                rate(controller_runtime_reconcile_total{
-                  controller=~"workload|referenced-data|workload-deployment-federator"
-                }[5m])
+                rate(controller_runtime_reconcile_total{job="compute-metrics"}[5m])
               ) > 0.5
             )
             and on (controller)
             (
               max by (controller) (
-                max_over_time(workqueue_depth{
-                  name=~"workload|referenced-data|workload-deployment-federator"
-                }[5m])
+                max_over_time(workqueue_depth{job="compute-metrics"}[5m])
               ) < 5
             )
-          for: 10m
+          for: 15m
           labels:
             severity: warning
-            service: compute-management-controllers
+            service: compute-controllers
             namespace: compute-system
             team: compute
           annotations:
             summary: Compute {{ $labels.controller }} controller is reconciling in a hot loop
             description: |
-              The compute management controller "{{ $labels.controller }}" has
-              been reconciling at {{ $value | humanize }}/s (>30/min) for 10
-              minutes while its workqueue has stayed drained. Idle Workloads are
-              being re-reconciled in a self-perpetuating loop, burning
-              control-plane capacity without doing real work.
+              The compute controller "{{ $labels.controller }}" has been
+              reconciling at {{ $value | humanize }}/s (>30/min) for 15 minutes
+              while its workqueue has stayed drained. The same objects are being
+              re-reconciled in a self-perpetuating loop, burning control-plane
+              capacity without doing real work.
 
               Reconciles succeed, so reconcile_errors_total will look healthy.
               Confirm by comparing the reconcile rate against workqueue_depth and
-              the Workload/WorkloadDeployment count, which stay small and stable.
+              the object count for this controller's resource, which stay small
+              and stable during a storm.
 
-              See the runbook for the known root cause (annotation ping-pong
-              between the workload and referenced-data controllers) and
-              remediation.
+              The firing controller label tells you where to look. See the
+              runbook for confirmation queries, known causes, and remediation.
             runbook_url: https://github.com/datum-cloud/compute/blob/main/docs/runbooks/compute-management-controller-reconcile-storm.md
 
         # Corroborating signal on the same fingerprint from the workqueue side:
-        # a high add rate is what feeds the loop. workqueue metrics label the
-        # controller as "name" rather than "controller".
-        - alert: ComputeManagementControllerWorkqueueAddStorm
+        # a high add rate against a drained queue is what feeds the loop.
+        # workqueue metrics label the controller as "name" rather than
+        # "controller".
+        - alert: ComputeControllerWorkqueueAddStorm
           expr: |
             (
               sum by (name) (
-                rate(workqueue_adds_total{
-                  name=~"workload|referenced-data|workload-deployment-federator"
-                }[5m])
+                rate(workqueue_adds_total{job="compute-metrics"}[5m])
               ) > 0.5
             )
             and on (name)
             (
               max by (name) (
-                max_over_time(workqueue_depth{
-                  name=~"workload|referenced-data|workload-deployment-federator"
-                }[5m])
+                max_over_time(workqueue_depth{job="compute-metrics"}[5m])
               ) < 5
             )
-          for: 10m
+          for: 15m
           labels:
             severity: warning
-            service: compute-management-controllers
+            service: compute-controllers
             namespace: compute-system
             team: compute
           annotations:
             summary: Compute {{ $labels.name }} controller workqueue is churning while drained
             description: |
-              The compute management controller "{{ $labels.name }}" has been
-              enqueuing work at {{ $value | humanize }}/s (>30/min) for 10
-              minutes while its workqueue depth has stayed near zero. Items are
-              being re-added as fast as they drain, which is the enqueue-side
-              signature of the idle-Workload reconcile loop.
+              The compute controller "{{ $labels.name }}" has been enqueuing work
+              at {{ $value | humanize }}/s (>30/min) for 15 minutes while its
+              workqueue depth has stayed near zero. Items are being re-added as
+              fast as they drain, which is the enqueue-side signature of a
+              reconcile loop.
+
+              The firing controller label tells you where to look. See the
+              runbook for confirmation queries, known causes, and remediation.
             runbook_url: https://github.com/datum-cloud/compute/blob/main/docs/runbooks/compute-management-controller-reconcile-storm.md

--- a/config/components/alerts/reconcile-storm.yaml
+++ b/config/components/alerts/reconcile-storm.yaml
@@ -1,0 +1,95 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  labels:
+    alert-group: compute
+    app.kubernetes.io/name: compute
+    app.kubernetes.io/component: management-controllers
+    app.kubernetes.io/managed-by: kustomize
+  name: compute-management-controller-alerts
+spec:
+  groups:
+    - name: compute-management-controllers.reconcile-storm
+      rules:
+        # Management controllers (workload, referenced-data,
+        # workload-deployment-federator) re-reconcile idle Workloads in a
+        # self-perpetuating loop: reconciles keep succeeding but produce no work,
+        # so the fingerprint is a high reconcile rate while the workqueue stays
+        # drained. reconcile_errors_total stays flat, so error-based alerts miss
+        # this entirely.
+        - alert: ComputeManagementControllerReconcileStorm
+          expr: |
+            (
+              sum by (controller) (
+                rate(controller_runtime_reconcile_total{
+                  controller=~"workload|referenced-data|workload-deployment-federator"
+                }[5m])
+              ) > 0.5
+            )
+            and on (controller)
+            (
+              max by (controller) (
+                max_over_time(workqueue_depth{
+                  name=~"workload|referenced-data|workload-deployment-federator"
+                }[5m])
+              ) < 5
+            )
+          for: 10m
+          labels:
+            severity: warning
+            service: compute-management-controllers
+            namespace: compute-system
+            team: compute
+          annotations:
+            summary: Compute {{ $labels.controller }} controller is reconciling in a hot loop
+            description: |
+              The compute management controller "{{ $labels.controller }}" has
+              been reconciling at {{ $value | humanize }}/s (>30/min) for 10
+              minutes while its workqueue has stayed drained. Idle Workloads are
+              being re-reconciled in a self-perpetuating loop, burning
+              control-plane capacity without doing real work.
+
+              Reconciles succeed, so reconcile_errors_total will look healthy.
+              Confirm by comparing the reconcile rate against workqueue_depth and
+              the Workload/WorkloadDeployment count, which stay small and stable.
+
+              See the runbook for the known root cause (annotation ping-pong
+              between the workload and referenced-data controllers) and
+              remediation.
+            runbook_url: https://github.com/datum-cloud/compute/blob/main/docs/runbooks/compute-management-controller-reconcile-storm.md
+
+        # Corroborating signal on the same fingerprint from the workqueue side:
+        # a high add rate is what feeds the loop. workqueue metrics label the
+        # controller as "name" rather than "controller".
+        - alert: ComputeManagementControllerWorkqueueAddStorm
+          expr: |
+            (
+              sum by (name) (
+                rate(workqueue_adds_total{
+                  name=~"workload|referenced-data|workload-deployment-federator"
+                }[5m])
+              ) > 0.5
+            )
+            and on (name)
+            (
+              max by (name) (
+                max_over_time(workqueue_depth{
+                  name=~"workload|referenced-data|workload-deployment-federator"
+                }[5m])
+              ) < 5
+            )
+          for: 10m
+          labels:
+            severity: warning
+            service: compute-management-controllers
+            namespace: compute-system
+            team: compute
+          annotations:
+            summary: Compute {{ $labels.name }} controller workqueue is churning while drained
+            description: |
+              The compute management controller "{{ $labels.name }}" has been
+              enqueuing work at {{ $value | humanize }}/s (>30/min) for 10
+              minutes while its workqueue depth has stayed near zero. Items are
+              being re-added as fast as they drain, which is the enqueue-side
+              signature of the idle-Workload reconcile loop.
+            runbook_url: https://github.com/datum-cloud/compute/blob/main/docs/runbooks/compute-management-controller-reconcile-storm.md

--- a/config/overlays/management-plane/kustomization.yaml
+++ b/config/overlays/management-plane/kustomization.yaml
@@ -14,6 +14,7 @@ components:
   - ../../components/resource-metrics
   - ../../components/high-availability
   - ../../components/management-controllers
+  - ../../components/alerts
   - ../../components/csi-webhook-cert
 
 patches:

--- a/config/overlays/single-cluster/kustomization.yaml
+++ b/config/overlays/single-cluster/kustomization.yaml
@@ -16,4 +16,5 @@ components:
   - ../../components/high-availability
   - ../../components/csi-webhook-cert
   - ../../components/management-controllers
+  - ../../components/alerts
   - ../../components/cell-controllers

--- a/docs/runbooks/compute-management-controller-reconcile-storm.md
+++ b/docs/runbooks/compute-management-controller-reconcile-storm.md
@@ -1,0 +1,144 @@
+# Runbook: Compute management controller reconcile storm
+
+**Alerts:** `ComputeManagementControllerReconcileStorm`, `ComputeManagementControllerWorkqueueAddStorm`
+**Severity:** warning
+**Component:** compute management controllers (`compute-system/compute-manager`)
+**Related:** [datum-cloud/compute#191](https://github.com/datum-cloud/compute/issues/191) (this issue), companion fix in #192
+
+## What this alert means
+
+Compute's management controllers — `workload`, `referenced-data`, and
+`workload-deployment-federator` — are re-reconciling idle Workloads in a
+self-perpetuating loop. Nothing about the Workloads is actually changing; the
+controllers keep waking each other (and themselves) up and doing no useful work.
+
+Each reconcile **succeeds**, so error-based alerting stays silent. The tell is a
+high reconcile / enqueue rate while the workqueue stays drained (depth ~0) and
+the number of Workloads and WorkloadDeployments is small and stable.
+
+Left unchecked, this wastes control-plane CPU and apiserver capacity and adds
+background noise that makes real reconcile activity harder to see. It is a
+capacity and observability problem, not (yet) a correctness one.
+
+## Impact
+
+- Wasted control-plane capacity on the compute management plane (CPU on
+  `compute-manager`, write load on the project/management apiserver).
+- Genuine reconciles are harder to spot amid the churn.
+- No direct customer-facing Workload/Instance impact expected while it is only a
+  hot loop, but it erodes headroom and should be resolved.
+
+## How to confirm
+
+All queries run against the platform metrics store (`vmcluster-metrics`, e.g. via
+the staging Grafana / vmselect). The management-controller metrics are scraped
+from `compute-system/compute-metrics` by the platform vmagent.
+
+1. **Reconcile rate by controller** — should be small for a handful of idle
+   Workloads; during a storm it sits in the tens-to-hundreds per minute:
+
+   ```promql
+   sum by (controller) (
+     rate(controller_runtime_reconcile_total{
+       controller=~"workload|referenced-data|workload-deployment-federator"
+     }[5m])
+   ) * 60
+   ```
+
+2. **Enqueue rate vs. queue depth** — the smoking gun. A high add rate with a
+   depth pinned near zero means items are re-added as fast as they drain. Note
+   the workqueue metrics label the controller as `name`, not `controller`:
+
+   ```promql
+   # adds per minute (should track the reconcile rate during a storm)
+   sum by (name) (
+     rate(workqueue_adds_total{
+       name=~"workload|referenced-data|workload-deployment-federator"
+     }[5m])
+   ) * 60
+
+   # depth stays ~0 the whole time
+   max by (name) (
+     workqueue_depth{name=~"workload|referenced-data|workload-deployment-federator"}
+   )
+   ```
+
+3. **Object count is tiny and stable** — confirms the rate is not just real work
+   from many Workloads:
+
+   ```promql
+   count(datum_cloud_compute_workload_info)
+   ```
+
+4. **Reconcile errors are flat** — confirms reconciles are succeeding, so do not
+   rely on this to detect the loop:
+
+   ```promql
+   sum by (controller) (
+     rate(controller_runtime_reconcile_errors_total{
+       controller=~"workload|referenced-data|workload-deployment-federator"
+     }[5m])
+   )
+   ```
+
+5. **apiserver write cross-check** — if the management/project apiserver metrics
+   are available in the same store, a self-perpetuating loop shows up as a steady
+   update/patch rate on WorkloadDeployments far above what the object count
+   warrants (a single WorkloadDeployment has been observed patched several times
+   per second):
+
+   ```promql
+   sum(rate(apiserver_request_total{resource="workloaddeployments",verb=~"update|patch"}[5m]))
+   ```
+
+   Note: the compute Workload/WorkloadDeployment resources are served by the
+   project/management control plane, whose apiserver metrics may not be scraped
+   into this store. If the query returns nothing, fall back to the controller and
+   workqueue signals above.
+
+6. **Eyeball the logs** — a storm produces a continuous stream of reconcile log
+   lines for the same handful of objects:
+
+   ```sh
+   kubectl logs -n compute-system deployment/compute-manager -f | \
+     grep -E 'workload|referenced-data|workload-deployment-federator'
+   ```
+
+   Watch for the same Workload / WorkloadDeployment names recurring many times
+   per second with no meaningful spec/status change between reconciles.
+
+## Known root cause
+
+The controllers ping-pong on an annotation: the `workload` controller and the
+`referenced-data` controller each write an annotation that the other treats as a
+change, so each write re-triggers the other's reconcile, which writes again. The
+`workload-deployment-federator` rides the same churn. The result is a steady-state
+loop over idle objects.
+
+The fix lives in the controller code and is tracked in companion PR **#192**
+(this alerting/runbook PR does not change controller behavior). See
+[#191](https://github.com/datum-cloud/compute/issues/191) for the full analysis.
+
+## Remediation
+
+- **Preferred:** roll out the controller fix (PR #192). Once merged and deployed,
+  the reconcile and enqueue rates drop back to near zero for idle Workloads and
+  both alerts clear on their own.
+- **Immediate mitigation** if the loop is degrading the control plane before the
+  fix is available: restart `compute-manager`
+  (`kubectl rollout restart deployment/compute-manager -n compute-system`). This
+  does **not** fix the loop — it will resume once reconciliation restarts — but
+  can buy time. Prefer shipping the fix.
+
+## Escalation
+
+If the fix is not yet available and the loop is causing measurable control-plane
+saturation (apiserver latency, `compute-manager` CPU throttling), escalate to the
+compute team and reference [#191](https://github.com/datum-cloud/compute/issues/191)
+and #192.
+
+## Expected steady state (alert cleared)
+
+For a small number of idle Workloads, reconcile and workqueue add rates should be
+near zero (occasional single reconciles on real changes only), workqueue depth
+~0, and errors flat.

--- a/docs/runbooks/compute-management-controller-reconcile-storm.md
+++ b/docs/runbooks/compute-management-controller-reconcile-storm.md
@@ -3,7 +3,6 @@
 **Alerts:** `ComputeControllerReconcileStorm`, `ComputeControllerWorkqueueAddStorm`
 **Severity:** warning
 **Component:** compute controllers (`compute-system/compute-manager`)
-**Related:** [datum-cloud/compute#191](https://github.com/datum-cloud/compute/issues/191) (one known instance), companion fix in #192
 
 ## What this alert means
 
@@ -91,8 +90,8 @@ to focus on the storming controller.
 5. **apiserver write cross-check** — if the relevant apiserver metrics are
    available in the same store, a self-perpetuating loop shows up as a steady
    update/patch rate on the storming controller's resource far above what the
-   object count warrants (during the #191 incident a single WorkloadDeployment
-   was patched several times per second):
+   object count warrants (a single object being patched several times per second
+   is a strong signal):
 
    ```promql
    sum(rate(apiserver_request_total{resource="workloaddeployments",verb=~"update|patch"}[5m]))
@@ -116,29 +115,27 @@ to focus on the storming controller.
 ## Known causes
 
 The root cause is controller-specific — the firing label is your starting point.
-A confirmed example is an **annotation ping-pong** between the `workload` and
-`referenced-data` controllers: each writes an annotation the other treats as a
-change, so each write re-triggers the other's reconcile, which writes again; the
-`workload-deployment-federator` rides the same churn. That specific loop is
-tracked in [#191](https://github.com/datum-cloud/compute/issues/191) with the fix
-in companion PR **#192**.
+One common shape is a **metadata write-fight** between two controllers: each
+writes a piece of metadata (an annotation, label, or status field) that the other
+treats as a change, so each write re-triggers the other's reconcile, which writes
+again. A related shape is a single controller that writes on every reconcile and
+then wakes itself on its own update.
 
 More generally, look for anything that makes a controller re-enqueue its own (or
-a peer's) objects without a real change: writes on every reconcile (status/
-annotation/label churn), watches that fire on self-authored updates, or requeues
-with a near-zero backoff. This alerting/runbook change does not alter controller
-behavior; it only surfaces the pattern.
+a peer's) objects without a real change: writes on every reconcile (status /
+annotation / label churn), watches that fire on self-authored updates, or
+requeues with a near-zero backoff.
 
 ## Remediation
 
 - **Identify the controller** from the firing `controller` / `name` label and use
   the queries above to confirm the drained-queue fingerprint.
-- **If it is the #191 loop:** roll out the controller fix (PR #192). Once merged
-  and deployed, the reconcile and enqueue rates for those controllers drop back
-  to near zero and both alerts clear on their own.
-- **For a newly surfaced controller:** inspect what that controller writes on
-  each reconcile and which watch/requeue re-triggers it; the fix is to stop
-  re-enqueuing on self-authored, no-op changes.
+- **Find what re-triggers it:** inspect what that controller writes on each
+  reconcile and which watch or requeue wakes it again. Look for a metadata
+  write-fight with a competing controller (two controllers editing the same
+  object) or a controller reacting to its own updates. The fix is to stop
+  re-enqueuing on self-authored, no-op changes; once deployed the reconcile and
+  enqueue rates drop back to near zero and both alerts clear on their own.
 - **Immediate mitigation** if the loop is degrading the control plane before a
   fix is available: restart `compute-manager`
   (`kubectl rollout restart deployment/compute-manager -n compute-system`). This
@@ -149,8 +146,8 @@ behavior; it only surfaces the pattern.
 
 If no fix is available and the loop is causing measurable control-plane
 saturation (apiserver latency, `compute-manager` CPU throttling), escalate to the
-compute team. Reference the firing controller and, if it is the known instance,
-[#191](https://github.com/datum-cloud/compute/issues/191) and #192.
+compute team, naming the firing controller and the observed reconcile / enqueue
+rates.
 
 ## Expected steady state (alert cleared)
 

--- a/docs/runbooks/compute-management-controller-reconcile-storm.md
+++ b/docs/runbooks/compute-management-controller-reconcile-storm.md
@@ -1,20 +1,27 @@
-# Runbook: Compute management controller reconcile storm
+# Runbook: Compute controller reconcile storm
 
-**Alerts:** `ComputeManagementControllerReconcileStorm`, `ComputeManagementControllerWorkqueueAddStorm`
+**Alerts:** `ComputeControllerReconcileStorm`, `ComputeControllerWorkqueueAddStorm`
 **Severity:** warning
-**Component:** compute management controllers (`compute-system/compute-manager`)
-**Related:** [datum-cloud/compute#191](https://github.com/datum-cloud/compute/issues/191) (this issue), companion fix in #192
+**Component:** compute controllers (`compute-system/compute-manager`)
+**Related:** [datum-cloud/compute#191](https://github.com/datum-cloud/compute/issues/191) (one known instance), companion fix in #192
 
 ## What this alert means
 
-Compute's management controllers — `workload`, `referenced-data`, and
-`workload-deployment-federator` — are re-reconciling idle Workloads in a
-self-perpetuating loop. Nothing about the Workloads is actually changing; the
-controllers keep waking each other (and themselves) up and doing no useful work.
+A reconcile storm is a generic controller-runtime pathology: a compute
+controller re-reconciles the same objects in a self-perpetuating loop. Nothing
+about the objects is actually changing; the controller keeps waking itself (or a
+peer controller) up and doing no useful work.
+
+The alert is **per controller** and evaluates across every controller
+`compute-manager` reports — management-plane controllers (`workload`,
+`referenced-data`, `workload-deployment-federator`, `instance-projector`, ...)
+and cell-side controllers (`instance`, `workloaddeployment`, quota, ...) alike,
+including any controller added later. **The firing `controller` / `name` label
+tells you which controller is storming and therefore where to look.**
 
 Each reconcile **succeeds**, so error-based alerting stays silent. The tell is a
 high reconcile / enqueue rate while the workqueue stays drained (depth ~0) and
-the number of Workloads and WorkloadDeployments is small and stable.
+the number of objects for that controller's resource is small and stable.
 
 Left unchecked, this wastes control-plane CPU and apiserver capacity and adds
 background noise that makes real reconcile activity harder to see. It is a
@@ -22,8 +29,8 @@ capacity and observability problem, not (yet) a correctness one.
 
 ## Impact
 
-- Wasted control-plane capacity on the compute management plane (CPU on
-  `compute-manager`, write load on the project/management apiserver).
+- Wasted control-plane capacity on the compute control plane (CPU on
+  `compute-manager`, write load on the project/management or cell apiserver).
 - Genuine reconciles are harder to spot amid the churn.
 - No direct customer-facing Workload/Instance impact expected while it is only a
   hot loop, but it erodes headroom and should be resolved.
@@ -31,18 +38,21 @@ capacity and observability problem, not (yet) a correctness one.
 ## How to confirm
 
 All queries run against the platform metrics store (`vmcluster-metrics`, e.g. via
-the staging Grafana / vmselect). The management-controller metrics are scraped
-from `compute-system/compute-metrics` by the platform vmagent.
+the staging Grafana / vmselect). The compute controller metrics are scraped from
+`compute-system/compute-metrics` by the platform vmagent, so `job="compute-metrics"`
+scopes every query to `compute-manager`. Filter on the firing `controller` label
+to focus on the storming controller.
 
 1. **Reconcile rate by controller** — should be small for a handful of idle
-   Workloads; during a storm it sits in the tens-to-hundreds per minute:
+   objects; during a storm the offending controller sits in the
+   tens-to-hundreds per minute:
 
    ```promql
-   sum by (controller) (
-     rate(controller_runtime_reconcile_total{
-       controller=~"workload|referenced-data|workload-deployment-federator"
-     }[5m])
-   ) * 60
+   sort_desc(
+     sum by (controller) (
+       rate(controller_runtime_reconcile_total{job="compute-metrics"}[5m])
+     ) * 60
+   )
    ```
 
 2. **Enqueue rate vs. queue depth** — the smoking gun. A high add rate with a
@@ -50,21 +60,20 @@ from `compute-system/compute-metrics` by the platform vmagent.
    the workqueue metrics label the controller as `name`, not `controller`:
 
    ```promql
-   # adds per minute (should track the reconcile rate during a storm)
-   sum by (name) (
-     rate(workqueue_adds_total{
-       name=~"workload|referenced-data|workload-deployment-federator"
-     }[5m])
-   ) * 60
+   # adds per minute (tracks the reconcile rate during a storm)
+   sort_desc(
+     sum by (name) (
+       rate(workqueue_adds_total{job="compute-metrics"}[5m])
+     ) * 60
+   )
 
    # depth stays ~0 the whole time
-   max by (name) (
-     workqueue_depth{name=~"workload|referenced-data|workload-deployment-federator"}
-   )
+   max by (name) (workqueue_depth{job="compute-metrics"})
    ```
 
 3. **Object count is tiny and stable** — confirms the rate is not just real work
-   from many Workloads:
+   from many objects. Pick the metric for the firing controller's resource, e.g.
+   for `workload`:
 
    ```promql
    count(datum_cloud_compute_workload_info)
@@ -75,56 +84,62 @@ from `compute-system/compute-metrics` by the platform vmagent.
 
    ```promql
    sum by (controller) (
-     rate(controller_runtime_reconcile_errors_total{
-       controller=~"workload|referenced-data|workload-deployment-federator"
-     }[5m])
+     rate(controller_runtime_reconcile_errors_total{job="compute-metrics"}[5m])
    )
    ```
 
-5. **apiserver write cross-check** — if the management/project apiserver metrics
-   are available in the same store, a self-perpetuating loop shows up as a steady
-   update/patch rate on WorkloadDeployments far above what the object count
-   warrants (a single WorkloadDeployment has been observed patched several times
-   per second):
+5. **apiserver write cross-check** — if the relevant apiserver metrics are
+   available in the same store, a self-perpetuating loop shows up as a steady
+   update/patch rate on the storming controller's resource far above what the
+   object count warrants (during the #191 incident a single WorkloadDeployment
+   was patched several times per second):
 
    ```promql
    sum(rate(apiserver_request_total{resource="workloaddeployments",verb=~"update|patch"}[5m]))
    ```
 
-   Note: the compute Workload/WorkloadDeployment resources are served by the
-   project/management control plane, whose apiserver metrics may not be scraped
-   into this store. If the query returns nothing, fall back to the controller and
-   workqueue signals above.
+   Note: compute resources are served by the project/management or cell control
+   plane, whose apiserver metrics may not be scraped into this store. If the
+   query returns nothing, fall back to the controller and workqueue signals
+   above.
 
 6. **Eyeball the logs** — a storm produces a continuous stream of reconcile log
    lines for the same handful of objects:
 
    ```sh
-   kubectl logs -n compute-system deployment/compute-manager -f | \
-     grep -E 'workload|referenced-data|workload-deployment-federator'
+   kubectl logs -n compute-system deployment/compute-manager -f | grep -i "<controller>"
    ```
 
-   Watch for the same Workload / WorkloadDeployment names recurring many times
-   per second with no meaningful spec/status change between reconciles.
+   Watch for the same object names recurring many times per second with no
+   meaningful spec/status change between reconciles.
 
-## Known root cause
+## Known causes
 
-The controllers ping-pong on an annotation: the `workload` controller and the
-`referenced-data` controller each write an annotation that the other treats as a
-change, so each write re-triggers the other's reconcile, which writes again. The
-`workload-deployment-federator` rides the same churn. The result is a steady-state
-loop over idle objects.
+The root cause is controller-specific — the firing label is your starting point.
+A confirmed example is an **annotation ping-pong** between the `workload` and
+`referenced-data` controllers: each writes an annotation the other treats as a
+change, so each write re-triggers the other's reconcile, which writes again; the
+`workload-deployment-federator` rides the same churn. That specific loop is
+tracked in [#191](https://github.com/datum-cloud/compute/issues/191) with the fix
+in companion PR **#192**.
 
-The fix lives in the controller code and is tracked in companion PR **#192**
-(this alerting/runbook PR does not change controller behavior). See
-[#191](https://github.com/datum-cloud/compute/issues/191) for the full analysis.
+More generally, look for anything that makes a controller re-enqueue its own (or
+a peer's) objects without a real change: writes on every reconcile (status/
+annotation/label churn), watches that fire on self-authored updates, or requeues
+with a near-zero backoff. This alerting/runbook change does not alter controller
+behavior; it only surfaces the pattern.
 
 ## Remediation
 
-- **Preferred:** roll out the controller fix (PR #192). Once merged and deployed,
-  the reconcile and enqueue rates drop back to near zero for idle Workloads and
-  both alerts clear on their own.
-- **Immediate mitigation** if the loop is degrading the control plane before the
+- **Identify the controller** from the firing `controller` / `name` label and use
+  the queries above to confirm the drained-queue fingerprint.
+- **If it is the #191 loop:** roll out the controller fix (PR #192). Once merged
+  and deployed, the reconcile and enqueue rates for those controllers drop back
+  to near zero and both alerts clear on their own.
+- **For a newly surfaced controller:** inspect what that controller writes on
+  each reconcile and which watch/requeue re-triggers it; the fix is to stop
+  re-enqueuing on self-authored, no-op changes.
+- **Immediate mitigation** if the loop is degrading the control plane before a
   fix is available: restart `compute-manager`
   (`kubectl rollout restart deployment/compute-manager -n compute-system`). This
   does **not** fix the loop — it will resume once reconciliation restarts — but
@@ -132,13 +147,13 @@ The fix lives in the controller code and is tracked in companion PR **#192**
 
 ## Escalation
 
-If the fix is not yet available and the loop is causing measurable control-plane
+If no fix is available and the loop is causing measurable control-plane
 saturation (apiserver latency, `compute-manager` CPU throttling), escalate to the
-compute team and reference [#191](https://github.com/datum-cloud/compute/issues/191)
-and #192.
+compute team. Reference the firing controller and, if it is the known instance,
+[#191](https://github.com/datum-cloud/compute/issues/191) and #192.
 
 ## Expected steady state (alert cleared)
 
-For a small number of idle Workloads, reconcile and workqueue add rates should be
+For a small number of idle objects, reconcile and workqueue add rates should be
 near zero (occasional single reconciles on real changes only), workqueue depth
 ~0, and errors flat.


### PR DESCRIPTION
## Why

Any compute controller can fall into a reconcile storm: it re-processes the same objects over and over in a self-perpetuating loop, burning control-plane capacity while doing no real work. It is a generic controller-runtime failure mode, not tied to one controller, and it also makes genuine reconcile activity harder to see.

The nasty part is that every reconcile still succeeds, so error-based alerting never fires and on-call has no signal for it today. This is exactly what is happening in staging right now. This PR gives on-call a paging signal that catches this pattern for **any** compute controller — management-plane and cell-side alike, plus any controller added later — before it erodes control-plane headroom, along with a runbook to confirm and remediate.

This is an alerting and docs change only; it does not change controller behavior. The specific loop currently active in staging is fixed separately in the companion controller PR. Rolling this out first lets us confirm the alert correctly flags the live incident ahead of that fix landing.

## What on-call gets

- A warning alert, evaluated per controller, that fires when a compute controller reconciles (or re-enqueues work) far above a healthy rate while its work backlog stays drained — the fingerprint of a self-perpetuating loop rather than genuine load. The alert names the offending controller so responders know immediately where to look.
- Guards against false alarms: the alert requires the drained-backlog condition and must hold for a sustained window, so a legitimate transient burst (for example a mass rollout that briefly drives a high but healthy reconcile rate) will not page.
- An operator runbook covering what the alert means, how to confirm it, the known causes (including the loop tracked in the linked issue), and how to remediate or escalate.

## Behavior

Verified live against staging: the alert currently surfaces the three controllers caught in the active loop and stays quiet for the rest. Once the underlying loop is fixed, those controllers fall back to a healthy rate and the alert clears on its own.

Part of #191. Companion to controller fix #192 (non-closing on purpose — the issue stays open until the fix is confirmed in staging).
