### PR TITLE
feat: add Status.Suspended to WorkloadDeployment watch predicate to e…

### DIFF
--- a/internal/controller/workloaddeployment_controller.go
+++ b/internal/controller/workloaddeployment_controller.go
@@ -319,7 +319,8 @@ func (r *WorkloadDeploymentReconciler) reconcileInstanceGates(
 // For() watch that fires on:
 //   - Any Create, Delete, or Generic event (always enqueue).
 //   - An Update event where metadata.generation changed (spec updated), OR where
-//     the ReferencedDataReady condition's Status, Reason, or Message changed.
+//     the ReferencedDataReady condition's Status, Reason, or Message changed, OR
+//     where Status.Suspended changed.
 //
 // The predicate intentionally does NOT fire when only the Available or
 // ReplicasReady conditions change, because those are written by this reconciler
@@ -335,6 +336,12 @@ func (r *WorkloadDeploymentReconciler) reconcileInstanceGates(
 // reconciler re-runs, sees the resolver verdict in deployment.Status.Conditions, and
 // promotes Available to ReferencedDataNotReady. Subsequent runs by this reconciler
 // (which write Available but not ReferencedDataReady) are filtered out.
+//
+// Status.Suspended is written out-of-band by ComputeSuspend/ComputeResume (see
+// suspend_hooks.go) via a Status().Patch that bumps resourceVersion but not
+// Generation, and doesn't touch ReferencedDataReady — so without this explicit
+// check that patch would be invisible to this predicate, and reconcileInstanceGates
+// would never propagate the suspension down to the owned Instances.
 func wdReferencedDataChangedPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -345,6 +352,11 @@ func wdReferencedDataChangedPredicate() predicate.Predicate {
 			}
 			// Spec change: always reconcile.
 			if oldWD.Generation != newWD.Generation {
+				return true
+			}
+			// Suspension state changed: reconcile so the suspend/resume is
+			// propagated down to the owned Instances.
+			if oldWD.Status.Suspended != newWD.Status.Suspended {
 				return true
 			}
 			// ReferencedDataReady condition changed: reconcile so Available is

--- a/internal/controller/workloaddeployment_controller_test.go
+++ b/internal/controller/workloaddeployment_controller_test.go
@@ -693,6 +693,23 @@ func TestWDPredicate_ReplicasReadyOnlyChange(t *testing.T) {
 		"predicate must drop update when only ReplicasReady changed")
 }
 
+// TestWDPredicate_SuspendedChanged verifies that the predicate passes when
+// Status.Suspended flips. ComputeSuspend/ComputeResume (suspend_hooks.go) write
+// this field via a Status().Patch that bumps resourceVersion but not Generation
+// and does not touch ReferencedDataReady — without this check the predicate
+// would drop the update and reconcileInstanceGates would never propagate the
+// suspension down to the owned Instances.
+func TestWDPredicate_SuspendedChanged(t *testing.T) {
+	pred := wdReferencedDataChangedPredicate()
+
+	oldWD, newWD := makeWDPair(1)
+	newWD.Status.Suspended = true
+
+	e := event.UpdateEvent{ObjectOld: oldWD, ObjectNew: newWD}
+	assert.True(t, pred.Update(e),
+		"predicate must pass when Status.Suspended changes")
+}
+
 // TestWDPredicate_CreateAlwaysPasses verifies that Create events always trigger
 // the reconciler regardless of conditions.
 func TestWDPredicate_CreateAlwaysPasses(t *testing.T) {


### PR DESCRIPTION
Suspending a project produced no effect in the compute service: no reconciliation logs.

**Root cause:** `ComputeSuspend`/`ComputeResume` (`suspend_hooks.go`) set suspension by patching `WorkloadDeployment.Status.Suspended` via `Status().Patch`. That patch bumps `resourceVersion` but not `Generation`, and doesn't touch the `ReferencedDataReady` condition. The `WorkloadDeploymentReconciler`'s watch predicate (`wdReferencedDataChangedPredicate`) only let Update events through on a generation change or a `ReferencedDataReady` change, so it silently dropped the suspend/resume patch. The WD reconciler never re-ran, so `reconcileInstanceGates` — the only code that copies `Status.Suspended` down onto owned Instances — never fired, and Instances never entered `reconcileSuspendedState`.

**Fix:** `wdReferencedDataChangedPredicate` now also passes the event through when `Status.Suspended` differs between old and new. This lets the suspend/resume patch reach the reconciler, which propagates the state to Instances as before — no other changes needed downstream, since the Instance controller's own watch already reconciles on any Instance status update.

## Testing

- Added `TestWDPredicate_SuspendedChanged` to cover the predicate passing the suspend/resume patch through.
- `go build ./...`, `go vet ./...`, and existing predicate tests pass.
