### PR TITLE
fix: WorkloadDeployment never labeled for suspend/resume hook scoping

### DIFF
--- a/internal/controller/suspend_hooks.go
+++ b/internal/controller/suspend_hooks.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	computev1alpha "go.datum.net/compute/api/v1alpha"
 )
@@ -57,6 +58,8 @@ func (cs *ComputeSuspend) SuspendConsumer(
 	consumerClient client.Client,
 	serviceNames []string,
 ) error {
+	logger := log.FromContext(ctx)
+	logger.Info("SuspendConsumer hook invoked", "consumerProject", consumerProject, "serviceNames", serviceNames)
 	for _, svcName := range serviceNames {
 		// Suspend all WorkloadDeployments
 		var wds computev1alpha.WorkloadDeploymentList
@@ -65,6 +68,7 @@ func (cs *ComputeSuspend) SuspendConsumer(
 		); err != nil {
 			return fmt.Errorf("listing workloaddeployments for service %q: %w", svcName, err)
 		}
+		logger.Info("found workloaddeployments to suspend", "consumerProject", consumerProject, "service", svcName, "count", len(wds.Items))
 		for i := range wds.Items {
 			wd := &wds.Items[i]
 			if wd.Status.Suspended {
@@ -82,6 +86,7 @@ func (cs *ComputeSuspend) SuspendConsumer(
 				return fmt.Errorf("patching workloaddeployment %s/%s status to suspended: %w",
 					wd.Namespace, wd.Name, err)
 			}
+			logger.Info("workloaddeployment suspended", "consumerProject", consumerProject, "workloadDeployment", client.ObjectKeyFromObject(wd))
 			if cs.recorder != nil {
 				cs.recorder.Eventf(wd, nil, corev1.EventTypeNormal,
 					eventReasonProjectPaused, eventActionSuspending,
@@ -118,6 +123,8 @@ func (cr *ComputeResume) ResumeConsumer(
 	consumerClient client.Client,
 	serviceNames []string,
 ) error {
+	logger := log.FromContext(ctx)
+	logger.Info("ResumeConsumer hook invoked", "consumerProject", consumerProject, "serviceNames", serviceNames)
 	for _, svcName := range serviceNames {
 		// Resume all WorkloadDeployments
 		var wds computev1alpha.WorkloadDeploymentList
@@ -126,6 +133,7 @@ func (cr *ComputeResume) ResumeConsumer(
 		); err != nil {
 			return fmt.Errorf("listing workloaddeployments for service %q: %w", svcName, err)
 		}
+		logger.Info("found workloaddeployments to resume", "consumerProject", consumerProject, "service", svcName, "count", len(wds.Items))
 		for i := range wds.Items {
 			wd := &wds.Items[i]
 			if !wd.Status.Suspended {
@@ -143,6 +151,7 @@ func (cr *ComputeResume) ResumeConsumer(
 				return fmt.Errorf("patching workloaddeployment %s/%s status to resumed: %w",
 					wd.Namespace, wd.Name, err)
 			}
+			logger.Info("workloaddeployment resumed", "consumerProject", consumerProject, "workloadDeployment", client.ObjectKeyFromObject(wd))
 			if cr.recorder != nil {
 				cr.recorder.Eventf(wd, nil, corev1.EventTypeNormal,
 					eventReasonProjectResumed, eventActionResuming,

--- a/internal/controller/teardown.go
+++ b/internal/controller/teardown.go
@@ -23,6 +23,11 @@ import (
 // consumer project carries this label so disengage can target them by service.
 const labelServiceName = "services.miloapis.com/service-name"
 
+// labelServiceNameValue is this operator's canonical service name, the value
+// paired with labelServiceName on every resource the compute operator scopes
+// suspend/resume/teardown by (WorkloadDeployment, Instance).
+const labelServiceNameValue = "compute.datumapis.com"
+
 // ComputeTeardown implements consumer.Teardown. It is invoked after the
 // consumer provider has cancelled the per-cluster context and marked labeled
 // Instances for deletion via ManagedResources. It handles the parts a

--- a/internal/controller/workload_controller.go
+++ b/internal/controller/workload_controller.go
@@ -479,6 +479,7 @@ func (r *WorkloadReconciler) getDeploymentsForWorkload(
 					Name:      deploymentName,
 					Labels: map[string]string{
 						computev1alpha.WorkloadUIDLabel: string(workload.UID),
+						labelServiceName:                labelServiceNameValue,
 					},
 				},
 				Spec: computev1alpha.WorkloadDeploymentSpec{


### PR DESCRIPTION
## Summary
- `ComputeSuspend.SuspendConsumer` / `ComputeResume.ResumeConsumer` list `WorkloadDeployment`s scoped by the `services.miloapis.com/service-name` label, but nothing ever set that label on a `WorkloadDeployment` — only on `Instance` (`stateful_control.go`). The hooks' `List` call therefore always returned zero `WorkloadDeployment`s, so `Status.Suspended` never propagated to a project's workloads on a `ProjectSuspension`, in any environment.
- Fixes it by labeling `WorkloadDeployment`s the same way `Instance`s already are. `mergeDeploymentMetadata` merges labels non-destructively on every reconcile, so existing `WorkloadDeployment`s self-heal — no backfill needed.
- Adds `log.Info` to the suspend/resume hooks, which previously only emitted Kubernetes Events and were otherwise silent in operator logs. This is what surfaced the label bug in the first place — without it there was no way to tell from logs whether a suspension signal ever reached these hooks.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/controller/...` (305 passed)
- [ ] Verify in staging: create a `ProjectSuspension` for a project with an active `WorkloadDeployment`, confirm `WorkloadDeployment.Status.Suspended` flips to `true` and the new hook logs appear in `compute-manager`.