### PR TITLE
fix: propagate suspend/resume via annotation, not hub-side Status.Suspended

### DIFF
--- a/api/v1alpha/annotations.go
+++ b/api/v1alpha/annotations.go
@@ -46,4 +46,21 @@ const (
 	// ReferencedDataReady flips True), so the absence of the annotation means
 	// either no error or the error has cleared.
 	ReferencedDataErrorAnnotation = AnnotationNamespace + "/referenced-data-error"
+
+	// SuspendedAnnotation is set on a project-namespace WorkloadDeployment by the
+	// ComputeSuspend/ComputeResume consumer hooks to request that the cell stop
+	// (or resume) the instances it manages, in response to a project suspension
+	// signal. Its value is the string "true" or "false".
+	//
+	// This is an annotation rather than a direct Status.Suspended write for the
+	// same federation-boundary reason as ReferencedDataErrorAnnotation, but in
+	// the opposite direction: Karmada propagates metadata.annotations hub→cell,
+	// but the hub's WorkloadDeploymentFederator does not propagate Status
+	// hub→cell either — it only ever pulls the cell's aggregated status back up
+	// (syncStatusFromDownstream). A hub-side Status.Suspended write is therefore
+	// invisible to the cell and gets silently overwritten by the next status
+	// sync from downstream. The cell's own WorkloadDeploymentReconciler reads
+	// this annotation on its local copy and sets Status.Suspended itself, which
+	// then aggregates back up to the hub normally.
+	SuspendedAnnotation = AnnotationNamespace + "/suspended"
 )

--- a/config/components/controller_rbac/role.yaml
+++ b/config/components/controller_rbac/role.yaml
@@ -24,7 +24,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - compute.datumapis.com
   resources:
@@ -69,7 +68,6 @@ rules:
   resources:
   - locations
   - networkcontexts
-  - networks
   - subnets
   verbs:
   - get

--- a/config/components/controller_rbac/role.yaml
+++ b/config/components/controller_rbac/role.yaml
@@ -24,6 +24,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - compute.datumapis.com
   resources:
@@ -68,6 +69,7 @@ rules:
   resources:
   - locations
   - networkcontexts
+  - networks
   - subnets
   verbs:
   - get

--- a/internal/controller/suspend_hooks.go
+++ b/internal/controller/suspend_hooks.go
@@ -32,21 +32,30 @@ const (
 	eventActionResuming   = "Resuming"
 )
 
-// ComputeSuspend implements consumer.Suspend. It sets spec.suspended=true on
-// every Instance owned by the suspended consumer project, scoped by the
-// services.miloapis.com/service-name label. It is idempotent: instances that
-// are already suspended are skipped.
+// ComputeSuspend implements consumer.Suspend. It requests that every
+// WorkloadDeployment owned by the suspended consumer project stop its
+// instances, scoped by the services.miloapis.com/service-name label. It is
+// idempotent: deployments already carrying the request are skipped.
 //
-// On success it emits a ProjectPaused event on each affected Instance.
-// On any patch failure it emits a PauseFailed Warning event on that Instance
-// and returns the error immediately so the service-catalog provider retries
-// with backoff. No teardown or deletion is ever attempted.
+// The request is made via SuspendedAnnotation rather than a direct
+// Status.Suspended write. Status.Suspended is aggregated hub-side from the
+// cell's own status (WorkloadDeploymentFederator.syncStatusFromDownstream),
+// which overwrites any hub-side write to it on the next sync — a direct write
+// here would be silently reverted. The annotation rides the same
+// metadata.annotations channel Karmada propagates hub→cell, so the cell's own
+// WorkloadDeploymentReconciler can read it and set Status.Suspended locally,
+// where it is the authoritative writer.
+//
+// On success it emits a ProjectPaused event on each affected WorkloadDeployment.
+// On any patch failure it emits a PauseFailed Warning event on that
+// WorkloadDeployment and returns the error immediately so the service-catalog
+// provider retries with backoff. No teardown or deletion is ever attempted.
 type ComputeSuspend struct {
 	recorder events.EventRecorder
 }
 
 // NewComputeSuspend creates a ComputeSuspend. recorder is used to emit
-// ProjectPaused / PauseFailed events on affected Instance objects.
+// ProjectPaused / PauseFailed events on affected WorkloadDeployment objects.
 func NewComputeSuspend(recorder events.EventRecorder) *ComputeSuspend {
 	return &ComputeSuspend{recorder: recorder}
 }
@@ -71,47 +80,53 @@ func (cs *ComputeSuspend) SuspendConsumer(
 		logger.Info("found workloaddeployments to suspend", "consumerProject", consumerProject, "service", svcName, "count", len(wds.Items))
 		for i := range wds.Items {
 			wd := &wds.Items[i]
-			if wd.Status.Suspended {
-				continue // already suspended — idempotent
+			if wd.Annotations[computev1alpha.SuspendedAnnotation] == "true" {
+				continue // already requested — idempotent
 			}
 			base := wd.DeepCopy()
-			wd.Status.Suspended = true
-			if err := consumerClient.Status().Patch(ctx, wd, client.MergeFrom(base)); err != nil {
+			if wd.Annotations == nil {
+				wd.Annotations = make(map[string]string)
+			}
+			wd.Annotations[computev1alpha.SuspendedAnnotation] = "true"
+			if err := consumerClient.Patch(ctx, wd, client.MergeFrom(base)); err != nil {
 				if cs.recorder != nil {
 					cs.recorder.Eventf(wd, nil, corev1.EventTypeWarning,
 						eventReasonPauseFailed, eventActionSuspending,
 						"Failed to suspend workloaddeployment %s/%s for project %s: %v",
 						wd.Namespace, wd.Name, consumerProject, err)
 				}
-				return fmt.Errorf("patching workloaddeployment %s/%s status to suspended: %w",
+				return fmt.Errorf("patching workloaddeployment %s/%s suspended annotation: %w",
 					wd.Namespace, wd.Name, err)
 			}
-			logger.Info("workloaddeployment suspended", "consumerProject", consumerProject, "workloadDeployment", client.ObjectKeyFromObject(wd))
+			logger.Info("workloaddeployment suspend requested", "consumerProject", consumerProject, "workloadDeployment", client.ObjectKeyFromObject(wd))
 			if cs.recorder != nil {
 				cs.recorder.Eventf(wd, nil, corev1.EventTypeNormal,
 					eventReasonProjectPaused, eventActionSuspending,
-					"WorkloadDeployment suspended due to project suspension of %s", consumerProject)
+					"WorkloadDeployment suspend requested due to project suspension of %s", consumerProject)
 			}
 		}
 	}
 	return nil
 }
 
-// ComputeResume implements consumer.Resume. It clears spec.suspended on every
-// Instance owned by the reinstated consumer project, scoped by the
-// services.miloapis.com/service-name label. It is idempotent: instances that
-// are already active are skipped.
+// ComputeResume implements consumer.Resume. It clears the suspend request on
+// every WorkloadDeployment owned by the reinstated consumer project, scoped
+// by the services.miloapis.com/service-name label. It is idempotent:
+// deployments not currently carrying the request are skipped.
 //
-// On success it emits a ProjectResumed event on each affected Instance.
-// On any patch failure it emits a PauseFailed Warning event on that Instance
-// and returns the error immediately so the service-catalog provider retries
-// with backoff. No teardown or deletion is ever attempted.
+// See ComputeSuspend's doc comment for why this writes SuspendedAnnotation
+// instead of Status.Suspended directly.
+//
+// On success it emits a ProjectResumed event on each affected WorkloadDeployment.
+// On any patch failure it emits a PauseFailed Warning event on that
+// WorkloadDeployment and returns the error immediately so the service-catalog
+// provider retries with backoff. No teardown or deletion is ever attempted.
 type ComputeResume struct {
 	recorder events.EventRecorder
 }
 
 // NewComputeResume creates a ComputeResume. recorder is used to emit
-// ProjectResumed / PauseFailed events on affected Instance objects.
+// ProjectResumed / PauseFailed events on affected WorkloadDeployment objects.
 func NewComputeResume(recorder events.EventRecorder) *ComputeResume {
 	return &ComputeResume{recorder: recorder}
 }
@@ -136,26 +151,26 @@ func (cr *ComputeResume) ResumeConsumer(
 		logger.Info("found workloaddeployments to resume", "consumerProject", consumerProject, "service", svcName, "count", len(wds.Items))
 		for i := range wds.Items {
 			wd := &wds.Items[i]
-			if !wd.Status.Suspended {
+			if wd.Annotations[computev1alpha.SuspendedAnnotation] != "true" {
 				continue // already active — idempotent
 			}
 			base := wd.DeepCopy()
-			wd.Status.Suspended = false
-			if err := consumerClient.Status().Patch(ctx, wd, client.MergeFrom(base)); err != nil {
+			delete(wd.Annotations, computev1alpha.SuspendedAnnotation)
+			if err := consumerClient.Patch(ctx, wd, client.MergeFrom(base)); err != nil {
 				if cr.recorder != nil {
 					cr.recorder.Eventf(wd, nil, corev1.EventTypeWarning,
 						eventReasonPauseFailed, eventActionResuming,
 						"Failed to resume workloaddeployment %s/%s for project %s: %v",
 						wd.Namespace, wd.Name, consumerProject, err)
 				}
-				return fmt.Errorf("patching workloaddeployment %s/%s status to resumed: %w",
+				return fmt.Errorf("patching workloaddeployment %s/%s suspended annotation: %w",
 					wd.Namespace, wd.Name, err)
 			}
-			logger.Info("workloaddeployment resumed", "consumerProject", consumerProject, "workloadDeployment", client.ObjectKeyFromObject(wd))
+			logger.Info("workloaddeployment resume requested", "consumerProject", consumerProject, "workloadDeployment", client.ObjectKeyFromObject(wd))
 			if cr.recorder != nil {
 				cr.recorder.Eventf(wd, nil, corev1.EventTypeNormal,
 					eventReasonProjectResumed, eventActionResuming,
-					"WorkloadDeployment resumed after project reinstatement of %s", consumerProject)
+					"WorkloadDeployment resume requested after project reinstatement of %s", consumerProject)
 			}
 		}
 	}

--- a/internal/controller/suspend_hooks.go
+++ b/internal/controller/suspend_hooks.go
@@ -30,6 +30,10 @@ const (
 
 	eventActionSuspending = "Suspending"
 	eventActionResuming   = "Resuming"
+
+	// suspendedAnnotationTrue is the SuspendedAnnotation value that requests
+	// suspension. Any other value, or absence of the annotation, means resumed.
+	suspendedAnnotationTrue = "true"
 )
 
 // ComputeSuspend implements consumer.Suspend. It requests that every
@@ -80,14 +84,14 @@ func (cs *ComputeSuspend) SuspendConsumer(
 		logger.Info("found workloaddeployments to suspend", "consumerProject", consumerProject, "service", svcName, "count", len(wds.Items))
 		for i := range wds.Items {
 			wd := &wds.Items[i]
-			if wd.Annotations[computev1alpha.SuspendedAnnotation] == "true" {
+			if wd.Annotations[computev1alpha.SuspendedAnnotation] == suspendedAnnotationTrue {
 				continue // already requested — idempotent
 			}
 			base := wd.DeepCopy()
 			if wd.Annotations == nil {
 				wd.Annotations = make(map[string]string)
 			}
-			wd.Annotations[computev1alpha.SuspendedAnnotation] = "true"
+			wd.Annotations[computev1alpha.SuspendedAnnotation] = suspendedAnnotationTrue
 			if err := consumerClient.Patch(ctx, wd, client.MergeFrom(base)); err != nil {
 				if cs.recorder != nil {
 					cs.recorder.Eventf(wd, nil, corev1.EventTypeWarning,
@@ -151,7 +155,7 @@ func (cr *ComputeResume) ResumeConsumer(
 		logger.Info("found workloaddeployments to resume", "consumerProject", consumerProject, "service", svcName, "count", len(wds.Items))
 		for i := range wds.Items {
 			wd := &wds.Items[i]
-			if wd.Annotations[computev1alpha.SuspendedAnnotation] != "true" {
+			if wd.Annotations[computev1alpha.SuspendedAnnotation] != suspendedAnnotationTrue {
 				continue // already active — idempotent
 			}
 			base := wd.DeepCopy()

--- a/internal/controller/suspend_hooks_test.go
+++ b/internal/controller/suspend_hooks_test.go
@@ -3,10 +3,12 @@
 package controller_test
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -101,4 +103,61 @@ func TestConformanceSuspendResume(t *testing.T) {
 		// No retained objects: the WorkloadDeployment itself is what the hooks operate on
 		// (status.suspended flips), so it is not a bystander that must stay unchanged.
 	)
+}
+
+// TestSuspendResumeSetsWorkloadDeploymentAnnotation verifies the actual
+// mechanism ComputeSuspend/ComputeResume use to request suspension: the
+// SuspendedAnnotation on the target WorkloadDeployment, not Status.Suspended
+// directly. A prior version of this hook wrote Status.Suspended directly,
+// which WorkloadDeploymentFederator's syncStatusFromDownstream silently
+// reverted on the next reconcile because Status is never propagated hub->cell
+// (see SuspendedAnnotation's doc comment) — a bug the generic conformance
+// test above cannot catch because it only asserts on ServiceConsumer's Paused
+// condition, not on the compute-specific field the hook actually writes.
+func TestSuspendResumeSetsWorkloadDeploymentAnnotation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := computev1alpha.AddToScheme(scheme); err != nil {
+		t.Fatalf("adding computev1alpha scheme: %v", err)
+	}
+
+	const serviceName = "compute.miloapis.com"
+	deployment := &computev1alpha.WorkloadDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-instance",
+			Namespace: "default",
+			Labels: map[string]string{
+				"services.miloapis.com/service-name": serviceName,
+			},
+		},
+	}
+
+	consumerClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(deployment).
+		WithStatusSubresource(deployment).
+		Build()
+
+	ctx := context.Background()
+	key := types.NamespacedName{Namespace: deployment.Namespace, Name: deployment.Name}
+
+	if err := controller.NewComputeSuspend(nil).SuspendConsumer(ctx, "test-project", consumerClient, []string{serviceName}); err != nil {
+		t.Fatalf("SuspendConsumer: %v", err)
+	}
+	var got computev1alpha.WorkloadDeployment
+	if err := consumerClient.Get(ctx, key, &got); err != nil {
+		t.Fatalf("get after suspend: %v", err)
+	}
+	if got.Annotations[computev1alpha.SuspendedAnnotation] != "true" {
+		t.Fatalf("SuspendedAnnotation = %q, want %q", got.Annotations[computev1alpha.SuspendedAnnotation], "true")
+	}
+
+	if err := controller.NewComputeResume(nil).ResumeConsumer(ctx, "test-project", consumerClient, []string{serviceName}); err != nil {
+		t.Fatalf("ResumeConsumer: %v", err)
+	}
+	if err := consumerClient.Get(ctx, key, &got); err != nil {
+		t.Fatalf("get after resume: %v", err)
+	}
+	if _, ok := got.Annotations[computev1alpha.SuspendedAnnotation]; ok {
+		t.Fatalf("SuspendedAnnotation still present after resume: %q", got.Annotations[computev1alpha.SuspendedAnnotation])
+	}
 }

--- a/internal/controller/workload_controller.go
+++ b/internal/controller/workload_controller.go
@@ -48,6 +48,7 @@ type WorkloadReconciler struct {
 // +kubebuilder:rbac:groups=compute.datumapis.com,resources=workloads,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=compute.datumapis.com,resources=workloads/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=compute.datumapis.com,resources=workloads/finalizers,verbs=update
+// +kubebuilder:rbac:groups=networking.datumapis.com,resources=networks,verbs=get;list;watch
 
 func (r *WorkloadReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)

--- a/internal/controller/workloaddeployment_controller.go
+++ b/internal/controller/workloaddeployment_controller.go
@@ -185,7 +185,7 @@ func (r *WorkloadDeploymentReconciler) Reconcile(ctx context.Context, req mcreco
 	// reconcileInstanceGates propagates it to owned Instances below, is what
 	// lets the request actually take effect and lets the resulting status
 	// reach the hub.
-	deployment.Status.Suspended = deployment.Annotations[computev1alpha.SuspendedAnnotation] == "true"
+	deployment.Status.Suspended = deployment.Annotations[computev1alpha.SuspendedAnnotation] == suspendedAnnotationTrue
 
 	replicas := len(instances.Items)
 	desiredReplicas := deployment.Spec.ScaleSettings.MinReplicas

--- a/internal/controller/workloaddeployment_controller.go
+++ b/internal/controller/workloaddeployment_controller.go
@@ -176,6 +176,17 @@ func (r *WorkloadDeploymentReconciler) Reconcile(ctx context.Context, req mcreco
 	// will result in this reconciler being processed again, so will properly have
 	// their gates removed.
 
+	// Translate the suspend/resume request carried on SuspendedAnnotation
+	// (written hub-side by the ComputeSuspend/ComputeResume consumer hooks and
+	// propagated here by WorkloadDeploymentFederator) into Status.Suspended.
+	// This cell is the authoritative writer of Status.Suspended: Karmada only
+	// aggregates status cell->hub, so a hub-side write to this field is
+	// silently reverted by the next aggregation. Writing it here, before
+	// reconcileInstanceGates propagates it to owned Instances below, is what
+	// lets the request actually take effect and lets the resulting status
+	// reach the hub.
+	deployment.Status.Suspended = deployment.Annotations[computev1alpha.SuspendedAnnotation] == "true"
+
 	replicas := len(instances.Items)
 	desiredReplicas := deployment.Spec.ScaleSettings.MinReplicas
 	if dt := deployment.DeletionTimestamp; !dt.IsZero() {
@@ -337,11 +348,15 @@ func (r *WorkloadDeploymentReconciler) reconcileInstanceGates(
 // promotes Available to ReferencedDataNotReady. Subsequent runs by this reconciler
 // (which write Available but not ReferencedDataReady) are filtered out.
 //
-// Status.Suspended is written out-of-band by ComputeSuspend/ComputeResume (see
-// suspend_hooks.go) via a Status().Patch that bumps resourceVersion but not
-// Generation, and doesn't touch ReferencedDataReady — so without this explicit
-// check that patch would be invisible to this predicate, and reconcileInstanceGates
-// would never propagate the suspension down to the owned Instances.
+// SuspendedAnnotation is written out-of-band: hub-side by ComputeSuspend/
+// ComputeResume (see suspend_hooks.go), then propagated onto this cell's copy
+// by WorkloadDeploymentFederator via Karmada. That's a metadata-only change —
+// same Generation, and Status.Suspended hasn't been derived from it yet — so
+// without this explicit check the annotation change would be invisible to
+// this predicate, and Reconcile would never run to translate it into
+// Status.Suspended in the first place. The Status.Suspended check below
+// additionally catches this reconciler's own follow-up write of that
+// translation, so a slow-to-engage cell still converges.
 func wdReferencedDataChangedPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -352,6 +367,11 @@ func wdReferencedDataChangedPredicate() predicate.Predicate {
 			}
 			// Spec change: always reconcile.
 			if oldWD.Generation != newWD.Generation {
+				return true
+			}
+			// Suspend/resume request changed: reconcile so it's translated into
+			// Status.Suspended and propagated down to the owned Instances.
+			if oldWD.Annotations[computev1alpha.SuspendedAnnotation] != newWD.Annotations[computev1alpha.SuspendedAnnotation] {
 				return true
 			}
 			// Suspension state changed: reconcile so the suspend/resume is

--- a/internal/controller/workloaddeployment_controller_test.go
+++ b/internal/controller/workloaddeployment_controller_test.go
@@ -694,11 +694,9 @@ func TestWDPredicate_ReplicasReadyOnlyChange(t *testing.T) {
 }
 
 // TestWDPredicate_SuspendedChanged verifies that the predicate passes when
-// Status.Suspended flips. ComputeSuspend/ComputeResume (suspend_hooks.go) write
-// this field via a Status().Patch that bumps resourceVersion but not Generation
-// and does not touch ReferencedDataReady — without this check the predicate
-// would drop the update and reconcileInstanceGates would never propagate the
-// suspension down to the owned Instances.
+// Status.Suspended flips. This reconciler is the sole writer of that field
+// (derived from SuspendedAnnotation, see Reconcile), and this check lets a
+// slow-to-engage cell's own follow-up write still converge.
 func TestWDPredicate_SuspendedChanged(t *testing.T) {
 	pred := wdReferencedDataChangedPredicate()
 
@@ -708,6 +706,27 @@ func TestWDPredicate_SuspendedChanged(t *testing.T) {
 	e := event.UpdateEvent{ObjectOld: oldWD, ObjectNew: newWD}
 	assert.True(t, pred.Update(e),
 		"predicate must pass when Status.Suspended changes")
+}
+
+// TestWDPredicate_SuspendedAnnotationChanged verifies that the predicate
+// passes when SuspendedAnnotation flips. ComputeSuspend/ComputeResume
+// (suspend_hooks.go) write this annotation hub-side, which
+// WorkloadDeploymentFederator propagates onto this cell's copy via Karmada —
+// a metadata-only change (same Generation, Status.Suspended not yet derived
+// from it) that would otherwise be invisible to this predicate, leaving
+// Reconcile never triggered to translate the request into Status.Suspended.
+func TestWDPredicate_SuspendedAnnotationChanged(t *testing.T) {
+	pred := wdReferencedDataChangedPredicate()
+
+	oldWD, newWD := makeWDPair(1)
+	if newWD.Annotations == nil {
+		newWD.Annotations = make(map[string]string)
+	}
+	newWD.Annotations[computev1alpha.SuspendedAnnotation] = "true"
+
+	e := event.UpdateEvent{ObjectOld: oldWD, ObjectNew: newWD}
+	assert.True(t, pred.Update(e),
+		"predicate must pass when SuspendedAnnotation changes")
 }
 
 // TestWDPredicate_CreateAlwaysPasses verifies that Create events always trigger

--- a/internal/controller/workloaddeployment_federator.go
+++ b/internal/controller/workloaddeployment_federator.go
@@ -277,6 +277,18 @@ func (r *WorkloadDeploymentFederator) upsertDownstreamDeployment(
 		} else {
 			delete(kd.Annotations, computev1alpha.ExpectedReferencedDataAnnotation)
 		}
+		// Propagate the suspend request so the cell can act on it: Status is
+		// never pushed hub->cell (only pulled cell->hub in
+		// syncStatusFromDownstream), so SuspendedAnnotation is the only channel
+		// the ComputeSuspend/ComputeResume hooks have to reach the cell.
+		if anno, ok := deployment.Annotations[computev1alpha.SuspendedAnnotation]; ok {
+			if kd.Annotations == nil {
+				kd.Annotations = make(map[string]string)
+			}
+			kd.Annotations[computev1alpha.SuspendedAnnotation] = anno
+		} else {
+			delete(kd.Annotations, computev1alpha.SuspendedAnnotation)
+		}
 		return nil
 	})
 	if err != nil {

--- a/internal/controller/workloaddeployment_federator.go
+++ b/internal/controller/workloaddeployment_federator.go
@@ -88,7 +88,7 @@ type WorkloadDeploymentFederator struct {
 // +kubebuilder:rbac:groups=compute.datumapis.com,resources=workloaddeployments,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=compute.datumapis.com,resources=workloaddeployments/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=compute.datumapis.com,resources=workloaddeployments/finalizers,verbs=update
-// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 
 func (r *WorkloadDeploymentFederator) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
 	if r.FederationClient == nil {

--- a/test/e2e/suspension/chainsaw-test.yaml
+++ b/test/e2e/suspension/chainsaw-test.yaml
@@ -1,0 +1,283 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: suspension
+spec:
+  description: |
+    Verifies that a suspend/resume request reaches a real cell and its
+    Instance, and that the resulting Status.Suspended is visible back on the
+    control-plane WorkloadDeployment.
+
+    ComputeSuspend/ComputeResume (compute/internal/controller/suspend_hooks.go)
+    are not exercised here — they live one layer up, in the service-catalog
+    consumer-provider, and are not part of this e2e environment. This test
+    starts from what they do: patch compute.datumapis.com/suspended onto the
+    control-plane WorkloadDeployment. From there it verifies the actual fix
+    under test — the annotation-based propagation path — end to end:
+
+    1. Create WorkloadDeployment on control-plane; wait for it to federate to
+       Karmada, propagate to pop-dfw, and produce an Instance there.
+    2. Patch compute.datumapis.com/suspended=true onto the control-plane WD.
+    3. WorkloadDeploymentFederator copies the annotation to the Karmada copy
+       (upsertDownstreamDeployment) — annotations are one of the few things
+       Karmada propagates hub→cell, unlike Status, which is never propagated
+       in that direction.
+    4. Karmada propagates the annotation to the pop-dfw copy.
+    5. pop-dfw's WorkloadDeploymentReconciler derives Status.Suspended=true
+       from the annotation on its local copy, before reconcileInstanceGates
+       propagates it to the owned Instance.
+    6. Status.Suspended rides the existing generic status-aggregation path
+       back up: pop-dfw → Karmada → control-plane, with no additional code
+       needed for that direction (WorkloadDeploymentFederator.
+       syncStatusFromDownstream already mirrors the whole status struct).
+    7. Removing the annotation (resume) reverses every step above.
+
+    Prerequisites: the management + both cell operators are deployed
+    in-cluster (task e2e:up).
+
+  template: true
+
+  steps:
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # SETUP: get a real, federated Instance on pop-dfw to suspend/resume
+  # ═══════════════════════════════════════════════════════════════════════
+
+  - name: create-workload-deployment
+    description: Create the WorkloadDeployment on the control-plane cluster.
+    try:
+    - apply:
+        file: workload-deployment.yaml
+
+  - name: assert-instance-on-pop-dfw
+    description: Wait for the full federation chain to produce an Instance on pop-dfw.
+    cluster: pop-dfw
+    try:
+    - script:
+        content: |
+          kubectl --kubeconfig=../../../tmp/e2e/kubeconfigs/control-plane.yaml \
+            get namespace "$NAMESPACE" \
+            -o template='{{printf "ns-%s" .metadata.uid}}'
+        outputs:
+        - name: cellNS
+          value: ($stdout)
+    - assert:
+        timeout: 120s
+        resource:
+          apiVersion: compute.datumapis.com/v1alpha
+          kind: Instance
+          metadata:
+            namespace: ($cellNS)
+            name: test-suspend-wd-0
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # SCENARIO 1: SUSPEND
+  # ═══════════════════════════════════════════════════════════════════════
+
+  - name: s1-suspend
+    description: Patch compute.datumapis.com/suspended=true onto the control-plane WD.
+    try:
+    - apply:
+        file: workload-deployment-suspended.yaml
+
+  - name: s1-assert-annotation-on-downstream
+    description: Assert the federator copied the annotation to the Karmada copy.
+    cluster: downstream
+    try:
+    - script:
+        content: |
+          kubectl --kubeconfig=../../../tmp/e2e/kubeconfigs/control-plane.yaml \
+            get namespace "$NAMESPACE" \
+            -o template='{{printf "ns-%s" .metadata.uid}}'
+        outputs:
+        - name: downstreamNS
+          value: ($stdout)
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: compute.datumapis.com/v1alpha
+          kind: WorkloadDeployment
+          metadata:
+            namespace: ($downstreamNS)
+            name: test-suspend-wd
+            annotations:
+              compute.datumapis.com/suspended: "true"
+
+  - name: s1-assert-suspended-on-pop-dfw
+    description: |
+      Assert Karmada propagated the annotation to pop-dfw, and the cell
+      reconciler derived Status.Suspended on both the WorkloadDeployment and
+      the Instance it owns.
+    cluster: pop-dfw
+    try:
+    - script:
+        content: |
+          kubectl --kubeconfig=../../../tmp/e2e/kubeconfigs/control-plane.yaml \
+            get namespace "$NAMESPACE" \
+            -o template='{{printf "ns-%s" .metadata.uid}}'
+        outputs:
+        - name: cellNS
+          value: ($stdout)
+    - assert:
+        timeout: 90s
+        resource:
+          apiVersion: compute.datumapis.com/v1alpha
+          kind: WorkloadDeployment
+          metadata:
+            namespace: ($cellNS)
+            name: test-suspend-wd
+            annotations:
+              compute.datumapis.com/suspended: "true"
+          status:
+            suspended: true
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: compute.datumapis.com/v1alpha
+          kind: Instance
+          metadata:
+            namespace: ($cellNS)
+            name: test-suspend-wd-0
+          status:
+            suspended: true
+
+  - name: s1-assert-suspended-status-on-downstream
+    description: |
+      Assert Karmada's ResourceInterpreterCustomization for WorkloadDeployment
+      (config/components/federation/workloaddeployment-interpreter.yaml)
+      aggregated the cell's whole Status object — including Suspended — onto
+      the Karmada resource template. This isolates Karmada's own aggregation
+      from WorkloadDeploymentFederator's separate job of then pulling it from
+      here into the control-plane WD (checked in the next step).
+    cluster: downstream
+    try:
+    - script:
+        content: |
+          kubectl --kubeconfig=../../../tmp/e2e/kubeconfigs/control-plane.yaml \
+            get namespace "$NAMESPACE" \
+            -o template='{{printf "ns-%s" .metadata.uid}}'
+        outputs:
+        - name: downstreamNS
+          value: ($stdout)
+    - assert:
+        timeout: 60s
+        resource:
+          apiVersion: compute.datumapis.com/v1alpha
+          kind: WorkloadDeployment
+          metadata:
+            namespace: ($downstreamNS)
+            name: test-suspend-wd
+          status:
+            suspended: true
+
+  - name: s1-assert-suspended-synced-to-control-plane
+    description: |
+      Assert WorkloadDeploymentFederator.syncStatusFromDownstream then pulls
+      that aggregated status from the Karmada copy into the control-plane WD,
+      with no annotation involved in this direction.
+    try:
+    - assert:
+        timeout: 60s
+        resource:
+          apiVersion: compute.datumapis.com/v1alpha
+          kind: WorkloadDeployment
+          metadata:
+            namespace: ($namespace)
+            name: test-suspend-wd
+          status:
+            suspended: true
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # SCENARIO 2: RESUME
+  # ═══════════════════════════════════════════════════════════════════════
+
+  - name: s2-resume
+    description: |
+      Remove compute.datumapis.com/suspended from the control-plane WD.
+      Re-applying workload-deployment.yaml (the manifest without the
+      annotation) does NOT reliably remove it: CRDs don't support strategic
+      merge patch, and a plain merge patch of an omitted key is a no-op, not a
+      deletion — this mirrors kubectl's own `annotate key-` semantics, which
+      exists precisely because omission from a new manifest isn't deletion.
+      Removing it explicitly here matches what ComputeResume actually does in
+      production (suspend_hooks.go: delete(wd.Annotations, ...)).
+    try:
+    - script:
+        content: |
+          kubectl --kubeconfig=../../../tmp/e2e/kubeconfigs/control-plane.yaml \
+            annotate workloaddeployment test-suspend-wd \
+            --namespace "$NAMESPACE" \
+            compute.datumapis.com/suspended-
+
+  - name: s2-assert-resumed-on-pop-dfw
+    description: Assert the cell reconciler cleared Status.Suspended on both objects.
+    cluster: pop-dfw
+    try:
+    - script:
+        content: |
+          kubectl --kubeconfig=../../../tmp/e2e/kubeconfigs/control-plane.yaml \
+            get namespace "$NAMESPACE" \
+            -o template='{{printf "ns-%s" .metadata.uid}}'
+        outputs:
+        - name: cellNS
+          value: ($stdout)
+    - assert:
+        timeout: 90s
+        resource:
+          apiVersion: compute.datumapis.com/v1alpha
+          kind: WorkloadDeployment
+          metadata:
+            namespace: ($cellNS)
+            name: test-suspend-wd
+          # Suspended is `json:"suspended,omitempty"`, so a resumed (false)
+          # object may omit the key entirely rather than store it literally as
+          # false. This expression normalizes both "absent" and "present and
+          # false" to false, so it doesn't spuriously fail on an omitted key.
+          (status.suspended != null && status.suspended): false
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: compute.datumapis.com/v1alpha
+          kind: Instance
+          metadata:
+            namespace: ($cellNS)
+            name: test-suspend-wd-0
+          (status.suspended != null && status.suspended): false
+
+  - name: s2-assert-resumed-status-on-downstream
+    description: |
+      Assert Karmada's aggregation reflects the cleared Status.Suspended onto
+      the Karmada resource template, isolated from the federator's separate
+      pull into the control-plane WD (checked in the next step).
+    cluster: downstream
+    try:
+    - script:
+        content: |
+          kubectl --kubeconfig=../../../tmp/e2e/kubeconfigs/control-plane.yaml \
+            get namespace "$NAMESPACE" \
+            -o template='{{printf "ns-%s" .metadata.uid}}'
+        outputs:
+        - name: downstreamNS
+          value: ($stdout)
+    - assert:
+        timeout: 60s
+        resource:
+          apiVersion: compute.datumapis.com/v1alpha
+          kind: WorkloadDeployment
+          metadata:
+            namespace: ($downstreamNS)
+            name: test-suspend-wd
+          (status.suspended != null && status.suspended): false
+
+  - name: s2-assert-resumed-synced-to-control-plane
+    description: Assert Status.Suspended=false rides back up to the control-plane WD.
+    try:
+    - assert:
+        timeout: 60s
+        resource:
+          apiVersion: compute.datumapis.com/v1alpha
+          kind: WorkloadDeployment
+          metadata:
+            namespace: ($namespace)
+            name: test-suspend-wd
+          (status.suspended != null && status.suspended): false

--- a/test/e2e/suspension/workload-deployment-suspended.yaml
+++ b/test/e2e/suspension/workload-deployment-suspended.yaml
@@ -1,0 +1,23 @@
+apiVersion: compute.datumapis.com/v1alpha
+kind: WorkloadDeployment
+metadata:
+  name: test-suspend-wd
+  # namespace is injected by Chainsaw from ($namespace)
+  annotations:
+    compute.datumapis.com/suspended: "true"
+spec:
+  cityCode: dfw
+  placementName: default
+  workloadRef:
+    name: test-workload
+    uid: "00000000-0000-0000-0000-000000000001"
+  template:
+    spec:
+      runtime:
+        resources:
+          instanceType: datumcloud/d1-standard-2
+      networkInterfaces:
+      - network:
+          name: test-network
+  scaleSettings:
+    minReplicas: 1

--- a/test/e2e/suspension/workload-deployment.yaml
+++ b/test/e2e/suspension/workload-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: compute.datumapis.com/v1alpha
+kind: WorkloadDeployment
+metadata:
+  name: test-suspend-wd
+  # namespace is injected by Chainsaw from ($namespace)
+spec:
+  cityCode: dfw
+  placementName: default
+  workloadRef:
+    name: test-workload
+    uid: "00000000-0000-0000-0000-000000000001"
+  template:
+    spec:
+      runtime:
+        resources:
+          instanceType: datumcloud/d1-standard-2
+      networkInterfaces:
+      - network:
+          name: test-network
+  scaleSettings:
+    minReplicas: 1


### PR DESCRIPTION
# PR: fix: propagate suspend/resume via annotation, not hub-side Status.Suspended

## Summary

Project suspensions weren't stopping instances: `ComputeSuspend`/`ComputeResume` patched `WorkloadDeployment.Status.Suspended` directly on the project-namespace object, but that write was silently reverted. `WorkloadDeploymentFederator` never propagates `Status` hub→cell (only `Spec` and one specific annotation), and its `syncStatusFromDownstream` overwrites the entire project-namespace status with whatever Karmada aggregated from the cell on every reconcile — which fires immediately off the hook's own update. The patch logged success with no error, but the object's `resourceVersion` never actually changed.

This switches the hooks to write a `SuspendedAnnotation` instead, the same channel already used for `ExpectedReferencedDataAnnotation` — one of the few things Karmada does propagate hub→cell. The cell's own `WorkloadDeploymentReconciler` now derives `Status.Suspended` from that annotation locally, before `reconcileInstanceGates` propagates it to owned Instances. The cell is the correct authoritative writer here: Karmada only aggregates status cell→hub, never the reverse, so only the cell can honestly confirm suspension actually happened. `Status.Suspended` then rides the existing generic status-aggregation path back up to the hub — no federator changes needed for that direction.

`wdReferencedDataChangedPredicate` is extended to fire on the annotation changing too, since that's a metadata-only change (same `Generation`) that would otherwise never trigger the reconcile that acts on it.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (438 passed)
- [x] Added a test asserting the actual mechanism (`SuspendedAnnotation`), since the existing conformance test only checks `ServiceConsumer`'s `Paused` condition and hand-labels its fixture, so it wouldn't have caught this bug or the earlier `WorkloadDeployment` labeling bug either
- [ ] Re-run a real production suspension against a healthy, actively-running workload and confirm `Status.Suspended` reaches the `WorkloadDeployment`, propagates to `Instance`, and the pod is deleted (and recreated on resume)
