### PR TITLE
fix: pin both images via the bundle publish's new images: input

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,28 +17,9 @@ jobs:
       platforms: linux/amd64,linux/arm64
     secrets: inherit
 
-  publish-kustomize-bundles:
-    needs: publish-container-image
-    permissions:
-      id-token: write
-      contents: read
-      packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.14.0
-    with:
-      bundle-name: ghcr.io/datum-cloud/compute-kustomize
-      bundle-path: config
-      image-name: ghcr.io/datum-cloud/compute
-      image-overlays: config/base/manager
-    secrets: inherit
-
   # Deployed as a Component (config/components/consumer-ui-plugin) folded
   # into compute-manager's own kustomize bundle/Flux Kustomization — no
-  # separate bundle for this image. The Deployment references the floating
-  # v0.0.0-main tag (this reusable workflow never pushes :latest — its tag
-  # scheme is v0.0.0-main[-<timestamp>]/semver/sha only) with
-  # imagePullPolicy: Always; this is a static asset server, not a
-  # GitOps-tracked control-plane binary, so immutable per-commit tag
-  # pinning isn't worth a custom bundle-publish step here.
+  # separate bundle for this image.
   publish-consumer-ui-plugin-image:
     permissions:
       id-token: write
@@ -49,4 +30,26 @@ jobs:
       image-name: compute-consumer-ui-plugin
       context: ui/consumer/workloads
       dockerfile-path: ui/consumer/workloads/Dockerfile
+    secrets: inherit
+
+  # Stamps both compute's own apiserver image (config/base/manager) and the
+  # consumer-ui-plugin's image (config/components/consumer-ui-plugin) into
+  # one compute-kustomize bundle publish. The `images:` input (v1.20.0+)
+  # supports multiple {path, name, tag} entries in one invocation — the
+  # single image-name/image-overlays inputs it replaces can only stamp one
+  # image across N paths, which can't express "two different images, two
+  # different paths" at all.
+  publish-kustomize-bundles:
+    needs: [publish-container-image, publish-consumer-ui-plugin-image]
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.20.0
+    with:
+      bundle-name: ghcr.io/datum-cloud/compute-kustomize
+      bundle-path: config
+      images: |
+        - { path: config/base/manager, name: ghcr.io/datum-cloud/compute }
+        - { path: config/components/consumer-ui-plugin, name: ghcr.io/datum-cloud/compute-consumer-ui-plugin, tag: "${{ needs.publish-consumer-ui-plugin-image.outputs.tag }}" }
     secrets: inherit

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,6 +50,6 @@ jobs:
       bundle-name: ghcr.io/datum-cloud/compute-kustomize
       bundle-path: config
       images: |
-        - { path: config/base/manager, name: ghcr.io/datum-cloud/compute }
+        - { path: config/base/manager, name: ghcr.io/datum-cloud/compute, tag: "${{ needs.publish-container-image.outputs.tag }}" }
         - { path: config/components/consumer-ui-plugin, name: ghcr.io/datum-cloud/compute-consumer-ui-plugin, tag: "${{ needs.publish-consumer-ui-plugin-image.outputs.tag }}" }
     secrets: inherit

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,7 +33,9 @@ jobs:
 
   # Deployed as a Component (config/components/consumer-ui-plugin) folded
   # into compute-manager's own kustomize bundle/Flux Kustomization — no
-  # separate bundle for this image. The Deployment references :latest with
+  # separate bundle for this image. The Deployment references the floating
+  # v0.0.0-main tag (this reusable workflow never pushes :latest — its tag
+  # scheme is v0.0.0-main[-<timestamp>]/semver/sha only) with
   # imagePullPolicy: Always; this is a static asset server, not a
   # GitOps-tracked control-plane binary, so immutable per-commit tag
   # pinning isn't worth a custom bundle-publish step here.

--- a/config/components/consumer-ui-plugin/deployment.yaml
+++ b/config/components/consumer-ui-plugin/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: compute-consumer-ui-plugin
-          image: ghcr.io/datum-cloud/compute-consumer-ui-plugin:v0.0.0-main
+          image: ghcr.io/datum-cloud/compute-consumer-ui-plugin:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 8443

--- a/config/components/consumer-ui-plugin/deployment.yaml
+++ b/config/components/consumer-ui-plugin/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: compute-consumer-ui-plugin
-          image: ghcr.io/datum-cloud/compute-consumer-ui-plugin:latest
+          image: ghcr.io/datum-cloud/compute-consumer-ui-plugin:v0.0.0-main
           imagePullPolicy: Always
           ports:
             - containerPort: 8443


### PR DESCRIPTION
## Summary
`compute-consumer-ui-plugin` pods stuck in `ImagePullBackOff` in staging. `ghcr.io/datum-cloud/compute-consumer-ui-plugin:latest` doesn't exist — `publish-docker.yaml` never pushes a `:latest` tag.

First commit: floating `v0.0.0-main` tag as a quick fix.

Second commit: the real fix. `publish-kustomize-bundle.yaml@v1.20.0` added an `images:` input — multiple `{path, name, tag}` entries per invocation. Supersedes `image-name`/`image-overlays`, which stamps one image across N paths and can't pin two different images at two different paths. Bumped the pin from `v1.14.0` to `v1.20.0`, switched to `images:`. Both `compute`'s apiserver image and the plugin's image now get immutable tags in one `compute-kustomize` bundle publish.

## Test plan
- [x] `docker manifest inspect ghcr.io/datum-cloud/compute-consumer-ui-plugin:v0.0.0-main` resolves
- [x] `kustomize edit set image` works against a `kind: Component` kustomization, not just `kind: Kustomization`
- [x] Full `compute-manager` composition (`base/manager` + all its components) builds with both image references present
- [ ] After merge and Flux reconcile: pods `Running`, not `ImagePullBackOff`; both images carry immutable tags in the published bundle